### PR TITLE
Implement feature #697053

### DIFF
--- a/platform/x11/pdfapp.c
+++ b/platform/x11/pdfapp.c
@@ -1003,6 +1003,26 @@ static void pdfapp_gotouri(pdfapp_t *app, char *uri)
 	winopenuri(app, uri);
 }
 
+mark_t pdfapp_mk_mark(pdfapp_t *app) 
+{
+	mark_t result;
+	result.resolution = app->resolution;
+	result.rotation = app->rotate;
+	result.panx = app->panx;
+	result.pany = app->pany;
+	result.pageno = app->pageno;
+	return result;
+}
+
+void pdfapp_restore_mark(pdfapp_t *app, mark_t mark) 
+{
+	app->resolution = mark.resolution;
+	app->rotate = mark.rotation;
+	app->panx = mark.panx;
+	app->pany = mark.pany;
+	app->pageno = mark.pageno;
+}
+
 void pdfapp_gotopage(pdfapp_t *app, int number)
 {
 	app->issearching = 0;
@@ -1018,10 +1038,10 @@ void pdfapp_gotopage(pdfapp_t *app, int number)
 
 	if (app->histlen + 1 == 256)
 	{
-		memmove(app->hist, app->hist + 1, sizeof(int) * 255);
+		memmove(app->hist, app->hist + 1, sizeof(app->hist[0]) * 255);
 		app->histlen --;
 	}
-	app->hist[app->histlen++] = app->pageno;
+	app->hist[app->histlen++] = pdfapp_mk_mark(app);
 	app->pageno = number;
 	pdfapp_showpage(app, 1, 1, 1, 0, 0);
 }
@@ -1373,16 +1393,16 @@ void pdfapp_onkey(pdfapp_t *app, int c, int modifiers)
 		{
 			int idx = atoi(app->number);
 			if (idx >= 0 && idx < nelem(app->marks))
-				app->marks[idx] = app->pageno;
+				app->marks[idx] = pdfapp_mk_mark(app);
 		}
 		else
 		{
 			if (app->histlen + 1 == 256)
 			{
-				memmove(app->hist, app->hist + 1, sizeof(int) * 255);
+				memmove(app->hist, app->hist + 1, sizeof(app->hist[0]) * 255);
 				app->histlen --;
 			}
-			app->hist[app->histlen++] = app->pageno;
+			app->hist[app->histlen++] = pdfapp_mk_mark(app);
 		}
 		break;
 
@@ -1392,11 +1412,17 @@ void pdfapp_onkey(pdfapp_t *app, int c, int modifiers)
 			int idx = atoi(app->number);
 
 			if (idx >= 0 && idx < nelem(app->marks))
-				if (app->marks[idx] > 0)
-					app->pageno = app->marks[idx];
+				if (app->marks[idx].pageno > 0)
+				{
+					pdfapp_restore_mark(app, app->marks[idx]);
+					panto = DONT_PAN;
+				}				
 		}
 		else if (app->histlen > 0)
-			app->pageno = app->hist[--app->histlen];
+		{
+			pdfapp_restore_mark(app,app->hist[--app->histlen]);
+			panto = DONT_PAN;
+		}
 		break;
 
 	case 'p':

--- a/platform/x11/pdfapp.h
+++ b/platform/x11/pdfapp.h
@@ -17,6 +17,7 @@
 #define MAXRES 1152
 
 typedef struct pdfapp_s pdfapp_t;
+typedef struct mark_s mark_t;
 
 enum { ARROW, HAND, WAIT, CARET };
 
@@ -47,6 +48,14 @@ extern void winadvancetimer(pdfapp_t *, float duration);
 extern void winreplacefile(char *source, char *target);
 extern void wincopyfile(char *source, char *target);
 extern void winreloadpage(pdfapp_t *);
+
+struct mark_s 
+{
+	int rotation;
+	int pageno;
+	int resolution;
+	int panx, pany;
+};
 
 struct pdfapp_s
 {
@@ -96,9 +105,9 @@ struct pdfapp_s
 	int incomplete;
 
 	/* snapback history */
-	int hist[256];
+	mark_t hist[256];
 	int histlen;
-	int marks[10];
+	mark_t marks[10];
 
 	/* window system sizes */
 	int winw, winh;


### PR DESCRIPTION
This is the implementation of feature request #[697053](https://bugs.ghostscript.com/show_bug.cgi?id=697053).
The feature is implemented for both X11 and OpenGL apps. 'm'arking now remembers the position, zoom rate and rotation state. These properties are restored on 't'aking. 