### PR TITLE
Continuous AppImage build for each git push

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "thirdparty/jbig2dec"]
 	path = thirdparty/jbig2dec
-	url = ../jbig2dec.git
+	url = https://github.com/ArtifexSoftware/jbig2dec
 [submodule "thirdparty/mujs"]
 	path = thirdparty/mujs
-	url = ../mujs.git
+	url = https://github.com/ArtifexSoftware/mujs
 [submodule "thirdparty/freetype"]
 	path = thirdparty/freetype
-	url = ../thirdparty-freetype2.git
+	url = https://github.com/ArtifexSoftware/thirdparty-freetype2
 [submodule "thirdparty/harfbuzz"]
 	path = thirdparty/harfbuzz
-	url = ../thirdparty-harfbuzz.git
+	url = https://github.com/ArtifexSoftware/thirdparty-harfbuzz
 [submodule "thirdparty/jpeg"]
 	path = thirdparty/libjpeg
-	url = ../thirdparty-libjpeg.git
+	url = https://github.com/ArtifexSoftware/thirdparty-libjpeg
 [submodule "thirdparty/lcms2"]
 	path = thirdparty/lcms2
-	url = ../thirdparty-lcms2.git
+	url = https://github.com/ArtifexSoftware/thirdparty-lcms2
 [submodule "thirdparty/openjpeg"]
 	path = thirdparty/openjpeg
-	url = ../thirdparty-openjpeg.git
+	url = https://github.com/ArtifexSoftware/thirdparty-openjpeg
 [submodule "thirdparty/zlib"]
 	path = thirdparty/zlib
-	url = ../thirdparty-zlib.git
+	url = https://github.com/ArtifexSoftware/thirdparty-zlib
 [submodule "thirdparty/curl"]
 	path = thirdparty/curl
-	url = ../thirdparty-curl.git
+	url = https://github.com/ArtifexSoftware/thirdparty-curl
 [submodule "thirdparty/freeglut"]
 	path = thirdparty/freeglut
-	url = ../thirdparty-freeglut.git
+	url = https://git.ghostscript.com/thirdparty-freeglut.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,39 @@ script:
   - gcc -Wl,--no-as-needed `pkg-config --cflags --libs gtk+-2.0` platform/x11/file_chooser.c -o file_chooser ; strip file_chooser
   - ( cd thirdparty/ ; git submodule init ; git submodule update )
   - make prefix=/usr install DESTDIR=$(readlink -f appdir) ; find appdir/
-  - cp file_chooser appdir/usr/bin
-  - mkdir -p ./appdir/usr/share/applications ; cp platform/x11/mupdf.desktop ./appdir/usr/share/applications/
+
   - mkdir -p ./appdir/usr/share/hicolor/scalable/apps ; wget -c "https://ghostscript.com/~tor/mupdf-logo/mupdf-logo.svg" -O ./appdir/usr/share/hicolor/scalable/apps/mupdf.svg
   - rm -rf  ./appdir/usr/include appdir/usr/lib/*.a # Don't need to ship developer files in AppImage
-  - rm ./appdir/usr/bin/{mjsgen,mujstest,mupdf-x11,mupdf-x11-curl,muraster,mutool} # Redundant?
+  
+  - # First, MuPDF
+  - cp -r appdir mupdf.AppDir
+  - cp file_chooser mupdf.AppDir/usr/bin
+  - mkdir -p ./mupdf.AppDir/usr/share/applications ; cp platform/x11/mupdf.desktop ./mupdf.AppDir/usr/share/applications/
+  - rm ./mupdf.AppDir/usr/bin/{mjsgen,mujstest,mupdf-x11,mupdf-x11-curl,muraster,mutool}
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/file_chooser -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
-
+  - ./linuxdeployqt*.AppImage ./mupdf.AppDir/usr/bin/file_chooser -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./mupdf.AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./mupdf.AppDir/usr/share/applications/*.desktop -appimage
+  - # Next, mutool
+  - cp -r appdir mutool.AppDir
+  - rm ./mutool.AppDir/usr/bin/{mjsgen,mujstest,muraster,mupdf*}
+  - mkdir -p ./mutool.AppDir/usr/share/applications ; cp platform/x11/mutool.desktop ./mutool.AppDir/usr/share/applications/
+  - ./linuxdeployqt*.AppImage ./mutool.AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./mutool.AppDir/usr/share/applications/*.desktop -appimage
+  - # Next, mujstest
+  - cp -r appdir mujstest.AppDir
+  - rm ./mujstest.AppDir/usr/bin/{mjsgen,mutool,muraster,mupdf*}
+  - mkdir -p ./mujstest.AppDir/usr/share/applications ; cp platform/x11/mujstest.desktop ./mujstest.AppDir/usr/share/applications/
+  - ./linuxdeployqt*.AppImage ./mujstest.AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./mujstest.AppDir/usr/share/applications/*.desktop -appimage
+  
 after_success:
-  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - rm ./linuxdeployqt*.AppImage
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-  - bash upload.sh ./MuPDF*.AppImage*
+  - bash upload.sh ./*.AppImage*
   
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+install:
+    - sudo apt-get -y install xorg-dev mesa-common-dev libgl1-mesa-dev libxcursor-dev libxrandr-dev libxinerama-dev libgtk2.0-dev
+
+script:
+  - gcc -Wl,--no-as-needed `pkg-config --cflags --libs gtk+-2.0` platform/x11/file_chooser.c -o file_chooser ; strip file_chooser
+  - ( cd thirdparty/ ; git submodule init ; git submodule update )
+  - make prefix=/usr install DESTDIR=$(readlink -f appdir) ; find appdir/
+  - cp file_chooser appdir/usr/bin
+  - mkdir -p ./appdir/usr/share/applications ; cp platform/x11/mupdf.desktop ./appdir/usr/share/applications/
+  - mkdir -p ./appdir/usr/share/hicolor/scalable/apps ; wget -c "https://ghostscript.com/~tor/mupdf-logo/mupdf-logo.svg" -O ./appdir/usr/share/hicolor/scalable/apps/mupdf.svg
+  - rm -rf  ./appdir/usr/include appdir/usr/lib/*.a # Don't need to ship developer files in AppImage
+  - rm ./appdir/usr/bin/{mjsgen,mujstest,mupdf-x11,mupdf-x11-curl,muraster,mutool} # Redundant?
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/file_chooser -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh ./MuPDF*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)$/

--- a/platform/x11/file_chooser.c
+++ b/platform/x11/file_chooser.c
@@ -1,0 +1,45 @@
+/* Shows file chooser dialog and returns selected file.
+ * THIS IS A STUB. FEEL FREE TO CHANGE AS YOU SEE FIT.
+ * Compile: 
+ * sudo apt install libgtk2.0-dev
+ * gcc -Wl,--no-as-needed `pkg-config --cflags --libs gtk+-2.0` file_chooser.c -o file_chooser */
+
+#include <gtk/gtk.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <dirent.h>
+
+
+int main(int argc, char *argv[])
+{
+    gchar *path;
+    GtkWidget *dialog;
+    int dlg_ret = 0;
+
+    char command[255];
+    char *dir = realpath( "/proc/self/exe", NULL );
+    if (!dir)
+    {
+        exit(1);
+    }
+
+    sprintf(command, "%s/mupdf-gl", dirname(dir));
+
+    gtk_init(&argc, &argv);
+    dialog = gtk_file_chooser_dialog_new("Select file", NULL, GTK_FILE_CHOOSER_ACTION_OPEN, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
+    dlg_ret = gtk_dialog_run(GTK_DIALOG(dialog));
+    if(dlg_ret == GTK_RESPONSE_ACCEPT)
+    {
+	path = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+        if( path!=NULL )
+        {
+            return execlp(command, command, path, NULL);
+        }
+    }
+    gtk_widget_destroy(dialog);
+    gtk_exit(0);
+    return 0;
+}

--- a/platform/x11/mujstest.desktop
+++ b/platform/x11/mujstest.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=mujstest
+Comment=Test tool for PDF files
+Exec=mujstest %f
+Icon=mupdf
+Terminal=true
+Type=Application
+MimeType=application/pdf;application/x-pdf
+Categories=Graphics;

--- a/platform/x11/mupdf.desktop
+++ b/platform/x11/mupdf.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=MuPDF
+GenericName=Lightweight PDF, XPS, and E-book viewer
+Exec=file_chooser %f
+Icon=mupdf
+Terminal=false
+Type=Application
+MimeType=application/pdf;application/x-pdf;application/x-cbz;application/oxps;application/vnd.ms-xpsdocument;image/jpeg;image/pjpeg;image/png;image/tiff;image/x-tiff
+Categories=Viewer;Graphics;

--- a/platform/x11/mupdf.desktop
+++ b/platform/x11/mupdf.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=MuPDF
-GenericName=Lightweight PDF, XPS, and E-book viewer
+Comment=Lightweight PDF, XPS, and E-book viewer
 Exec=file_chooser %f
 Icon=mupdf
 Terminal=false

--- a/platform/x11/mutool.desktop
+++ b/platform/x11/mutool.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=mutool
+Comment=All purpose tool for dealing with PDF files
+Exec=mutool %f
+Icon=mupdf
+Terminal=true
+Type=Application
+MimeType=application/pdf;application/x-pdf
+Categories=Graphics;


### PR DESCRIPTION
This PR, when merged, will compile MuPDF on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) for Linux to your GitHub Releases page.

This could be linked to from https://www.ghostscript.com/download/mupdfdnld.html

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.