### PR TITLE
vec_dot had wrong return type

### DIFF
--- a/source/fitz/stext-device.c
+++ b/source/fitz/stext-device.c
@@ -212,7 +212,7 @@ direction_from_bidi_class(int bidiclass, int curdir)
 	}
 }
 
-static int
+static float
 vec_dot(const fz_point *a, const fz_point *b)
 {
 	return a->x * b->x + a->y * b->y;


### PR DESCRIPTION
This caused a difference between release and debug builds in fz_new_stext_page_from_page. In debug the text structure was returned normally. In release characters belonging to a single line created new lines because vec_dot returned 0.

debug:

INSERTING WORD:         Subpart
INSERTING WORD:         2.2
INSERTING LINE
INSERTING WORD:         Hi
INSERTING WORD:         there!

release:

INSERTING WORD:         Subpart
INSERTING WORD:         2.2
INSERTING LINE
INSERTING WORD:         H
INSERTING LINE
INSERTING WORD:         i
INSERTING LINE
INSERTING WORD: 
INSERTING LINE
INSERTING WORD:         t
INSERTING LINE
INSERTING WORD:         h
INSERTING LINE
INSERTING WORD:         e
INSERTING LINE
INSERTING WORD:         r
INSERTING LINE
INSERTING WORD:         e
INSERTING LINE
INSERTING WORD:         !
INSERTING LINE

It occured with this [file](https://github.com/koreader/koreader-base/blob/master/spec/unit/data/testdocument.pdf) (password: test).
