### PR TITLE
Fixed handling of safebags in pkcs7-helper library

### DIFF
--- a/source/helpers/pkcs7/pkcs7-openssl.c
+++ b/source/helpers/pkcs7/pkcs7-openssl.c
@@ -517,11 +517,12 @@ static void add_from_bag(X509 **pX509, EVP_PKEY **pPkey, PKCS12_SAFEBAG *bag, co
 {
 	EVP_PKEY *pkey = NULL;
 	X509 *x509 = NULL;
+	STACK_OF(PKCS12_SAFEBAG) *bags;
 	switch (M_PKCS12_bag_type(bag))
 	{
 	case NID_keyBag:
 		{
-			const PKCS8_PRIV_KEY_INFO *p8 = PKCS12_SAFEBAG_get0_p8inf(bag);
+			const PKCS8_PRIV_KEY_INFO *p8 = PKCS12_decrypt_skey(bag, pw, (int)strlen(pw));
 			pkey = EVP_PKCS82PKEY(p8);
 		}
 		break;
@@ -543,7 +544,10 @@ static void add_from_bag(X509 **pX509, EVP_PKEY **pPkey, PKCS12_SAFEBAG *bag, co
 		break;
 
 	case NID_safeContentsBag:
-		add_from_bags(pX509, pPkey, PKCS12_SAFEBAG_get0_safes(bag), pw);
+		bags = sk_PKCS12_SAFEBAG_new_null();
+		sk_PKCS12_SAFEBAG_push(bags, bag);
+		add_from_bags(pX509, pPkey, bags, pw);
+		sk_PKCS12_SAFEBAG_free(bags);
 		break;
 	}
 


### PR DESCRIPTION
MuPDF doesn't build with LibreSSL unless this patch is applied.