### PR TITLE
Docker Build - centos:latest

### DIFF
--- a/docs/building.html
+++ b/docs/building.html
@@ -89,7 +89,7 @@ make prefix=/usr/local install
 To install only the command line tools, libraries, and headers invoke make like this:
 
 <pre>
-make HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install
+make --ignore-errors HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install
 </pre>
 
 </article>


### PR DESCRIPTION
It's like 3 am, not sure what was causing the install issue, the build is installing and working...
install -d /usr/local/include/mupdf
install -d /usr/local/include/mupdf/fitz
install -d /usr/local/include/mupdf/pdf
install -m 644 include/mupdf/*.h /usr/local/include/mupdf
install -m 644 include/mupdf/fitz/*.h /usr/local/include/mupdf/fitz
install -m 644 include/mupdf/pdf/*.h /usr/local/include/mupdf/pdf
install -d /usr/local/lib
install -m 644 build/release/libmupdf.a build/release/libmupdf-third.a /usr/local/lib
install -d /usr/local/bin
install -m 755 build/release/mutool build/release/muraster /usr/local/bin
install -m 755  /usr/local/bin
install: missing destination file operand after '/usr/local/bin'
Try 'install --help' for more information.
make: [install] Error 1 (ignored)
install -d /usr/local/share/man/man1
install -m 644 docs/man/*.1 /usr/local/share/man/man1
install -d /usr/local/share/doc/mupdf
install -d /usr/local/share/doc/mupdf/examples
install -m 644 README COPYING CHANGES /usr/local/share/doc/mupdf
install -m 644 docs/*.html docs/*.css docs/*.png /usr/local/share/doc/mupdf
install -m 644 docs/examples/* /usr/local/share/doc/mupdf/examples