### PR TITLE
Mouse side buttons for previous/next page

### DIFF
--- a/docs/manual-mupdf-gl.html
+++ b/docs/manual-mupdf-gl.html
@@ -47,6 +47,9 @@ The middle mouse button (scroll wheel button) pans the document view.
 
 <p>
 The right mouse button selects a region and copies the marked text to the clipboard.
+	
+<p>
+The mouse4/mouse5 side buttons go one page backward/forward.
 
 <h2>Key Bindings</h2>
 

--- a/platform/gl/gl-app.h
+++ b/platform/gl/gl-app.h
@@ -53,6 +53,8 @@ enum
 	KEY_F10,
 	KEY_F11,
 	KEY_F12,
+	MOUSE_SIDE_1,
+	MOUSE_SIDE_2,
 };
 
 enum side { ALL, T, R, B, L };

--- a/platform/gl/gl-main.c
+++ b/platform/gl/gl-main.c
@@ -1417,12 +1417,12 @@ static void do_app(void)
 		case 'g': jump_to_page(number - 1); break;
 		case 'G': jump_to_location(fz_last_page(ctx, doc)); break;
 
-		case ',': case KEY_PAGE_UP:
+		case ',': case KEY_PAGE_UP: case MOUSE_SIDE_1:
 			number = fz_maxi(number, 1);
 			while (number--)
 				currentpage = fz_previous_page(ctx, doc, currentpage);
 			break;
-		case '.': case KEY_PAGE_DOWN:
+		case '.': case KEY_PAGE_DOWN: case MOUSE_SIDE_2:
 			number = fz_maxi(number, 1);
 			while (number--)
 				currentpage = fz_next_page(ctx, doc, currentpage);

--- a/platform/gl/gl-ui.c
+++ b/platform/gl/gl-ui.c
@@ -307,6 +307,8 @@ static void on_mouse(int button, int action, int x, int y)
 		case 4: on_wheel(0, -1, x, y); break;
 		case 5: on_wheel(1, 1, x, y); break;
 		case 6: on_wheel(1, -1, x, y); break;
+		case 7: ui.key = MOUSE_SIDE_1; break;
+		case 8: ui.key = MOUSE_SIDE_2; break;
 		}
 	}
 	else if (action == GLUT_UP)
@@ -319,7 +321,9 @@ static void on_mouse(int button, int action, int x, int y)
 		}
 	}
 	ui.mod = glutGetModifiers();
+	ui.plain = !(ui.mod & ~GLUT_ACTIVE_SHIFT);
 	run_main_loop();
+	ui.key = ui.plain = 0;
 	ui_invalidate(); // TODO: leave this to caller
 }
 


### PR DESCRIPTION
I just started using MuPDF, and I thought a nice usability feature would be to switch pages with the mouse4 and mouse5 side buttons. Since you can already scroll, pan and zoom with the mouse, I think it makes sense to add page-turning.