### PR TITLE
Bug 702253: Avoid a use-after-free in fz_drop_band_writer

### DIFF
--- a/source/tools/mudraw.c
+++ b/source/tools/mudraw.c
@@ -933,7 +933,14 @@ static void dodrawpage(fz_context *ctx, fz_page *page, fz_display_list *list, in
 		fz_always(ctx)
 		{
 			if (output_format != OUT_PCLM)
+			{
 				fz_drop_band_writer(ctx, bander);
+				/* bander must be set to NULL to avoid use-after-frees. A use-after-free
+				 * would occur when a valid page was followed by a page with invalid
+				 * pixmap dimensions, causing bander -- a static -- to point to previously
+				 * freed memory instead of a new band_writer. */
+				bander = NULL;
+			}
 			fz_drop_bitmap(ctx, bit);
 			bit = NULL;
 			if (num_workers > 0)


### PR DESCRIPTION
A use-after-free would occur when a valid page was followed by
a page with invalid pixmap dimensions, causing bander --
a static -- to point to previously freed memory instead of a new
band_writer.