### PR TITLE
JS Outline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ platform/win32/Release
 platform/win32/ReleaseOpenssl
 platform/win32/Memento
 platform/win32/x64
+platform/win32/.vs

--- a/include/mupdf/fitz/outline.h
+++ b/include/mupdf/fitz/outline.h
@@ -27,7 +27,9 @@
 
 	down: The outline items immediate children in the hierarchy.
 	May be NULL if no children exist.
+	js: javascript action associated with this entry if applicable
 */
+
 typedef struct fz_outline
 {
 	int refs;
@@ -38,6 +40,7 @@ typedef struct fz_outline
 	struct fz_outline *next;
 	struct fz_outline *down;
 	int is_open;
+	char* js;
 } fz_outline;
 
 /**

--- a/include/mupdf/fitz/stream.h
+++ b/include/mupdf/fitz/stream.h
@@ -403,8 +403,10 @@ static inline int fz_peek_byte(fz_context *ctx, fz_stream *stm)
 
 	stm: The stream to operate upon.
 */
+
 static inline void fz_unread_byte(fz_context *ctx FZ_UNUSED, fz_stream *stm)
 {
+    ctx = ctx;
 	stm->rp--;
 }
 
@@ -525,6 +527,7 @@ static inline unsigned int fz_read_rbits(fz_context *ctx, fz_stream *stm, int n)
 */
 static inline void fz_sync_bits(fz_context *ctx FZ_UNUSED, fz_stream *stm)
 {
+    ctx = ctx;
 	stm->avail = 0;
 }
 

--- a/source/pdf/pdf-link.c
+++ b/source/pdf/pdf-link.c
@@ -404,11 +404,10 @@ pdf_load_link(fz_context *ctx, pdf_document *doc, pdf_obj *dict, int pagenum, fz
 	char *uri;
 	fz_link *link = NULL;
 
-	obj = pdf_dict_get(ctx, dict, PDF_NAME(Subtype));
-	if (!pdf_name_eq(ctx, obj, PDF_NAME(Link)))
-		return NULL;
+//	obj = pdf_dict_get(ctx, dict, PDF_NAME(Subtype));
+//      if (!pdf_name_eq(ctx, obj, PDF_NAME(Link)))
 
-	obj = pdf_dict_get(ctx, dict, PDF_NAME(Rect));
+        obj = pdf_dict_get(ctx, dict, PDF_NAME(Rect));
 	if (!obj)
 		return NULL;
 
@@ -424,7 +423,14 @@ pdf_load_link(fz_context *ctx, pdf_document *doc, pdf_obj *dict, int pagenum, fz
 		/* fall back to additional action button's down/up action */
 		if (!action)
 			action = pdf_dict_geta(ctx, pdf_dict_get(ctx, dict, PDF_NAME(AA)), PDF_NAME(U), PDF_NAME(D));
+
 		uri = pdf_parse_link_action(ctx, doc, action, pagenum);
+                if (!uri)
+                {
+                    pdf_obj *dobj = pdf_resolve_indirect(ctx, action);
+                    pdf_obj *  js  = pdf_dict_get(ctx, dobj, PDF_NAME(JS));
+                    uri = pdf_load_stream_or_string_as_utf8(ctx, js);
+                }
 	}
 
 	if (!uri)

--- a/source/pdf/pdf-outline.c
+++ b/source/pdf/pdf-outline.c
@@ -25,11 +25,19 @@ pdf_load_outline_imp(fz_context *ctx, pdf_document *doc, pdf_obj *dict)
 			obj = pdf_dict_get(ctx, dict, PDF_NAME(Title));
 			if (obj)
 				node->title = Memento_label(fz_strdup(ctx, pdf_to_text_string(ctx, obj)), "outline_title");
+			if ((obj = pdf_dict_get(ctx, dict, PDF_NAME(Next))) != NULL)
+			{
+				obj = pdf_resolve_indirect(ctx, obj);
+				if((obj = pdf_dict_get(ctx, obj, PDF_NAME(Title))) != NULL)
+					node->uri = Memento_label(fz_strdup(ctx, pdf_to_text_string(ctx, obj)), "outline_title");
+			}
 
 			if ((obj = pdf_dict_get(ctx, dict, PDF_NAME(Dest))) != NULL)
 				node->uri = Memento_label(pdf_parse_link_dest(ctx, doc, obj), "outline_uri");
 			else if ((obj = pdf_dict_get(ctx, dict, PDF_NAME(A))) != NULL)
+			{
 				node->uri = Memento_label(pdf_parse_link_action(ctx, doc, obj, -1), "outline_uri");
+			}
 			else
 				node->uri = NULL;
 
@@ -38,6 +46,11 @@ pdf_load_outline_imp(fz_context *ctx, pdf_document *doc, pdf_obj *dict)
 			else
 				node->page = -1;
 
+			if ((obj = pdf_dict_get(ctx, obj, PDF_NAME(Next))) != NULL) // insert javascript code if present
+			{
+				pdf_obj* js = pdf_dict_get(ctx, obj, PDF_NAME(JS));
+				node->js = pdf_load_stream_or_string_as_utf8(ctx, js);
+			}
 			obj = pdf_dict_get(ctx, dict, PDF_NAME(First));
 			if (obj)
 			{

--- a/source/pdf/pdf-page.c
+++ b/source/pdf/pdf-page.c
@@ -1101,7 +1101,7 @@ pdf_load_page_imp(fz_context *ctx, fz_document *doc_, int chapter, int number)
 			fz_rect page_mediabox;
 			fz_matrix page_ctm;
 			pdf_page_transform(ctx, page, &page_mediabox, &page_ctm);
-			page->links = pdf_load_link_annots(ctx, doc, obj, number, page_ctm);
+                        page->links = pdf_load_link_annots(ctx, doc, obj, number, page_ctm);
 			pdf_load_annots(ctx, page, obj);
 		}
 	}

--- a/source/tools/pdfshow.c
+++ b/source/tools/pdfshow.c
@@ -219,8 +219,17 @@ print_outline(fz_outline *outline, int level)
 			fz_write_byte(ctx, out, '|');
 
 		for (i = 0; i < level; i++)
-			fz_write_byte(ctx, out, '\t');
-		fz_write_printf(ctx, out, "%Q\t%s\n", outline->title, outline->uri);
+			fz_write_printf(ctx, out, "    ");
+		fz_write_printf(ctx, out, "%Q  %s", outline->title, outline->uri);
+		if (outline->js)
+		{
+			fz_write_printf(ctx, out, "  js: %s\n", outline->js);
+		}
+		else
+		{
+			fz_write_printf(ctx, out, "\n");
+		}
+
 		if (outline->down)
 			print_outline(outline->down, level + 1);
 		outline = outline->next;


### PR DESCRIPTION
The fz_outline structure is extended by a js field that holds the javascript associated with the entry.
This is useful to implement Find and Goto actions on the document.

![muttool](https://user-images.githubusercontent.com/24499580/101265781-76311300-3749-11eb-9d66-c095766aa91e.jpg)

In the "mutool show outline" tabs have been replaced with spaces but that is a matter of style and not important. Without the javascript the outline data structure is missing valuable information that is very difficult to obtain any other way through the API. 


