### PR TITLE
Mention name of missing zip entry in error message

### DIFF
--- a/source/fitz/unzip.c
+++ b/source/fitz/unzip.c
@@ -302,7 +302,7 @@ static fz_stream *open_zip_entry(fz_context *ctx, fz_archive *arch, const char *
 
 	ent = lookup_zip_entry(ctx, zip, name);
 	if (!ent)
-		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry");
+		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry '%s'", name);
 
 	method = read_zip_entry_header(ctx, zip, ent);
 	if (method == 0)
@@ -328,7 +328,7 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
 
 	ent = lookup_zip_entry(ctx, zip, name);
 	if (!ent)
-		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry");
+		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry '%s'", name);
 
 	method = read_zip_entry_header(ctx, zip, ent);
 	ubuf = fz_new_buffer(ctx, ent->usize + 1); /* +1 because many callers will add a terminating zero */


### PR DESCRIPTION

Otherwise, this information is lost, and it's useful to know which path was not found when debugging a broken file.