### PR TITLE
Fix argument order of PdfObject.forEach in documentation.

### DIFF
--- a/docs/src/mutool-object-pdf-object.rst
+++ b/docs/src/mutool-object-pdf-object.rst
@@ -86,7 +86,7 @@ All functions that take `PDFObjects`, do automatic translation between :title:`J
 
     Iterate over all the entries in a dictionary or array and call `fun` for each key-value pair.
 
-    :arg fun: Function in the format `function(key,value){...}`.
+    :arg fun: Function in the format `function(value,key){...}`.
 
 
 .. method:: push(item)


### PR DESCRIPTION
I was walking through trying to understand how to use the js interpreter, and noticed that the argument order
is wrong in the docs of forEach.  A trivial change, but hopefully will save someone a little work.