### PR TITLE
Fix AndroidImage implementation

### DIFF
--- a/platform/java/jni/android/androidimage.c
+++ b/platform/java/jni/android/androidimage.c
@@ -23,7 +23,7 @@
 /* AndroidImage interface */
 
 JNIEXPORT jlong JNICALL
-FUN(AndroidImage_newImageFromBitmap)(JNIEnv *env, jobject self, jobject jbitmap, jlong jmask)
+FUN(android_AndroidImage_newAndroidImageFromBitmap)(JNIEnv *env, jobject self, jobject jbitmap, jlong jmask)
 {
 	fz_context *ctx = get_context(env);
 	fz_image *mask = CAST(fz_image *, jmask);

--- a/platform/java/src/com/artifex/mupdf/fitz/android/AndroidImage.java
+++ b/platform/java/src/com/artifex/mupdf/fitz/android/AndroidImage.java
@@ -33,11 +33,15 @@ public final class AndroidImage extends Image
 		Context.init();
 	}
 
-	private native long newAndroidImageFromBitmap(Bitmap bitmap, long mask);
+	private static native long newAndroidImageFromBitmap(Bitmap bitmap, long mask);
+
+	public AndroidImage(Bitmap bitmap)
+	{
+		super(newAndroidImageFromBitmap(bitmap, 0));
+	}
 
 	public AndroidImage(Bitmap bitmap, AndroidImage mask)
 	{
-		super(0);
-		pointer = newAndroidImageFromBitmap(bitmap, mask.pointer);
+		super(newAndroidImageFromBitmap(bitmap, mask.pointer));
 	}
 }


### PR DESCRIPTION
The implementation seems broken.

1. It's not possible to create an instance without a mask
2. The native method isn't named correctly
    - Since self is never used I made it static
    - With the static native I made use of the super constructor
    - I kept the `pointer` field protected

I still have issues with this code, but it might be related to my `Bitmap` as I get following the error
> new Image failed as bitmap width != stride