### PR TITLE
Fix: pixmap.asJPEG not being able to set the image quality

### DIFF
--- a/source/fitz/output-jpeg.c
+++ b/source/fitz/output-jpeg.c
@@ -257,7 +257,7 @@ fz_save_pixmap_as_jpeg(fz_context *ctx, fz_pixmap *pixmap, const char *filename,
 }
 
 static fz_buffer *
-jpeg_from_pixmap(fz_context *ctx, fz_pixmap *pix, fz_color_params color_params, int quality, int drop)
+jpeg_from_pixmap(fz_context *ctx, fz_pixmap *pix, fz_color_params color_params, int drop, int quality)
 {
 	fz_buffer *buf = NULL;
 	fz_output *out = NULL;


### PR DESCRIPTION
Because of the inconsistency between the declaration of jpeg_from_pixmap and the parameter passing during invocation, it results in default quality being set to 1