### PR TITLE
Add font attributes from <g> element to child nodes

### DIFF
--- a/source/svg/svg-run.c
+++ b/source/svg/svg-run.c
@@ -1204,8 +1204,10 @@ svg_run_g(fz_context *ctx, fz_device *dev, svg_document *doc, fz_xml *root, cons
 {
 	svg_state local_state = *inherit_state;
 	fz_xml *node;
+	char font_family[100];
 
 	svg_parse_common(ctx, doc, root, &local_state);
+	svg_parse_font_attributes(ctx, doc, root, &local_state, font_family, sizeof font_family);
 
 	for (node = fz_xml_down(root); node; node = fz_xml_next(node))
 		svg_run_element(ctx, dev, doc, node, &local_state);


### PR DESCRIPTION
Previously, child nodes within the <g> element were not inheriting font attributes other than font-size.
https://github.com/sumatrapdfreader/sumatrapdf/issues/3747

declare font attributes directly on the <g> element, ensuring that these attributes are applied to its child nodes as well.
![image](https://github.com/ArtifexSoftware/mupdf/assets/50648835/03ee1930-6361-458e-9808-1a4f6f2cd2c1)
