### PR TITLE
fix time type on i686

### DIFF
--- a/platform/gl/gl-main.c
+++ b/platform/gl/gl-main.c
@@ -2556,7 +2556,7 @@ static char *short_signature_error_desc(pdf_signature_error err)
 	}
 }
 
-const char *format_date(int64_t secs)
+const char *format_date(int64_t secs64)
 {
 	static char buf[100];
 #ifdef _POSIX_SOURCE
@@ -2564,6 +2564,7 @@ const char *format_date(int64_t secs)
 #else
 	struct tm *tm;
 #endif
+	time_t secs = secs64;
 
 	if (secs <= 0)
 		return NULL;


### PR DESCRIPTION
Gcc14 turns some warnings into errors. Fix the time type error: mupdf uses int64_t internally, system libs use time_t which coincide in most architectures but not all of them.

Solves bug #707503