### PR TITLE
Add STDOUT output to mutool-convert

### DIFF
--- a/source/fitz/output.c
+++ b/source/fitz/output.c
@@ -245,8 +245,8 @@ fz_new_output_with_path(fz_context *ctx, const char *filename, int append)
 	FILE *file;
 	fz_output *out;
 
-	if (filename == NULL)
-		fz_throw(ctx, FZ_ERROR_ARGUMENT, "no output to write to");
+	if (filename == NULL || !strcmp(filename, "-") || !fz_strcasecmp(filename, "stdout"))
+		return fz_new_output(ctx, 0, NULL, stdout_write, NULL, NULL);
 
 	if (!strcmp(filename, "/dev/null") || !fz_strcasecmp(filename, "nul:"))
 		return fz_new_output(ctx, 0, NULL, null_write, NULL, NULL);

--- a/source/fitz/stext-output.c
+++ b/source/fitz/stext-output.c
@@ -933,6 +933,6 @@ fz_new_text_writer_with_output(fz_context *ctx, const char *format, fz_output *o
 fz_document_writer *
 fz_new_text_writer(fz_context *ctx, const char *format, const char *path, const char *options)
 {
-	fz_output *out = fz_new_output_with_path(ctx, path ? path : "out.txt", 0);
+	fz_output *out = fz_new_output_with_path(ctx, path, 0);
 	return fz_new_text_writer_with_output(ctx, format, out, options);
 }

--- a/source/tools/muconvert.c
+++ b/source/tools/muconvert.c
@@ -63,7 +63,7 @@ static int usage(void)
 		"\t-U -\tfile name of user stylesheet for EPUB layout\n"
 		"\t-X\tdisable document styles for EPUB layout\n"
 		"\n"
-		"\t-o -\toutput file name (%%d for page number)\n"
+		"\t-o -\toutput file name (%%d for page number, - for stdout)\n"
 		"\t-F -\toutput format (default inferred from output file name)\n"
 		"\t\t\traster: cbz, png, pnm, pgm, ppm, pam, pbm, pkm.\n"
 		"\t\t\tprint-raster: pcl, pclm, ps, pwg.\n"


### PR DESCRIPTION
Please add STDOUT output to `mutool-convert`.

Because it's not good to [mislead](https://github.com/ArtifexSoftware/mupdf/blob/d8219b8f234dff81cdca2da97d5bb86706737935/docs/man/mutool.1#L37) a user in a manual.