### PR TITLE
add missing header for fz_archive

### DIFF
--- a/include/mupdf/fitz/document.h
+++ b/include/mupdf/fitz/document.h
@@ -32,6 +32,7 @@
 #include "mupdf/fitz/link.h"
 #include "mupdf/fitz/outline.h"
 #include "mupdf/fitz/separation.h"
+#include "mupdf/fitz/archive.h"
 
 typedef struct fz_document_handler fz_document_handler;
 typedef struct fz_page fz_page;


### PR DESCRIPTION
2eb4c51a4 ("Reduce document handler open functions to a single one.", 2024-01-08) introduced an additional fz_archive argument. Include the header which defines the argument type.

https://bugs.ghostscript.com/show_bug.cgi?id=707682

(not sure whether you prefer PRs here or attachments there)