### PR TITLE
pdf_choice_widget_options2: avoid core dump with _GLIBCXX_ASSERTIONS

### DIFF
--- a/scripts/wrap/cpp.py
+++ b/scripts/wrap/cpp.py
@@ -1250,7 +1250,7 @@ g_extra_definitions = textwrap.dedent(f'''
         {{
             int n = pdf_choice_widget_options(ctx, tw, exportval, nullptr);
             std::vector<const char*> opts(n);
-            int n2 = pdf_choice_widget_options(ctx, tw, exportval, &opts[0]);
+            int n2 = pdf_choice_widget_options(ctx, tw, exportval, opts.data());
             assert(n2 == n);
             std::vector<std::string> ret(n);
             for (int i=0; i<n; ++i)


### PR DESCRIPTION
From a C programmer's view, &opts[0] == opts, but for the vector class in stdc++ there is a difference in if, where and when the existence of a zeroth element is checked. This matters for "empty" vectors only, but depending on g++/stdc++ version and flags this may throw an unexpected assertion and abort on run time. Noticed with gcc 15 on Fedora rawhide (42).

Replace &opts[0] by opts.data() which gives the pointer to the data storage of the vector, which is what pdf_choice_widget_options expects.