### PR TITLE
do not use CXXFLAGS with swig

### DIFF
--- a/scripts/wrap/swig.py
+++ b/scripts/wrap/swig.py
@@ -1810,7 +1810,7 @@ def build_swig(
                         -outdir {os.path.relpath(build_dirs.dir_mupdf)}/platform/python
                         -o {cpp}
                         -includeall
-                        {os.environ.get('XCXXFLAGS', '')}
+                        {os.environ.get('XSWIGFLAGS', '')}
                         -I{os.path.relpath(build_dirs.dir_mupdf)}/platform/python/include
                         -I{os.path.relpath(include1)}
                         -I{os.path.relpath(include2)}


### PR DESCRIPTION
swig does not take c++ flags, so do not apply XCXXFLAGS here. Instead, allow to use XSWIGFLAGS when needed. This in turn allows to specify XCXXFLAGS for c++ which swig does understand.

Noticed when trying to feed distribution flags to c++ - they include more than just `-I` which swig does understand.