### PR TITLE
Fix usage of JLIB_log_levels to set log level deltas from command line

### DIFF
--- a/scripts/jlib.py
+++ b/scripts/jlib.py
@@ -743,10 +743,6 @@ def text_split_last_of( text, substrings):
     return text[ :pos], text[ pos:]
 
 
-
-log_levels_add_env()
-
-
 def force_line_buffering():
     '''
     Ensure `sys.stdout` and `sys.stderr` are line-buffered. E.g. makes things
@@ -1244,6 +1240,9 @@ def time_duration( seconds, verbose=False, s_format='%i'):
     if seconds < 0:
         ret = '-%s' % ret
     return ret
+
+
+log_levels_add_env()
 
 
 def date_time( t=None):

--- a/scripts/jlib.py
+++ b/scripts/jlib.py
@@ -331,7 +331,11 @@ def log_levels_find( caller):
     if not s_log_levels_items:
         return 0
 
-    tb = traceback.extract_stack( None, 1+caller)
+    if isinstance(caller, inspect.FrameInfo):
+        tb = traceback.extract_stack( None, 1)
+    else:
+        tb = traceback.extract_stack( None, 1+caller)
+
     if len(tb) == 0:
         return 0
     filename, line, function, text = tb[0]

--- a/scripts/jlib.py
+++ b/scripts/jlib.py
@@ -509,7 +509,7 @@ def log_levels_add_env( name='JLIB_log_levels'):
             if 0:   # lgtm [py/unreachable-statement]
                 pass
             elif len( ffl) == 1:
-                filename = ffl
+                filename = ffl[0]
                 function = None
             elif len( ffl) == 2:
                 filename, function = ffl


### PR DESCRIPTION
This PR contains multiple fixes to be able to make use of JLIB_log_levels from the command line.
This is useful for example to be able to get libclang's diagnostics on stdout based on the environment variable's content.

Please review the last commit with caution ("jlib: fix unsupported operand type when setting log level"), as I'm not sure it is entirely correct.
`log_levels_find()` can be called with a FrameInfo caller, but it wasn't clear to me what `extract_stack()`'s limit should be in that case.

Any thought?