### PR TITLE
setup.py: add the non-versioned symlink to the build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -354,6 +354,8 @@ def build():
         names = [
                 pipcl.get_soname(f'{build_dir()}/libmupdf.so'),     # C.
                 pipcl.get_soname(f'{build_dir()}/libmupdfcpp.so'),  # C++.
+                f'{build_dir()}/libmupdf.so',                       # C symlink.
+                f'{build_dir()}/libmupdfcpp.so',                    # C++ symlink.
                 f'{build_dir()}/_mupdf.so',                         # Python internals.
                 f'{build_dir()}/mupdf.py',                          # Python.
                 ]


### PR DESCRIPTION
Starting from bf1c28cc4f2dd4bd17e35783fa3c1f98ded22296, the generated mupdf libraries are versioned. This means that if we want to link against them without knowing their version number (i.e. using '-lmupdf'), we also need to install the symlink to the wheel.