### PR TITLE
Migrate to maintained version of gumbo-parser

### DIFF
--- a/docs/src/third-party.rst
+++ b/docs/src/third-party.rst
@@ -50,7 +50,7 @@ These are the third party libraries used by :title:`MuPDF`.
      - Deflate compression
      - zlib License
    * - `gumbo-parser`_
-     - 0.10.1
+     - 0.13.0
      - HTML5 parser
      - Apache 2.0
    * - **Optional**
@@ -98,7 +98,7 @@ These are the third party libraries used by :title:`MuPDF`.
 .. _Incompatible fork of lcms2: http://git.ghostscript.com/?p=thirdparty-lcms2.git;a=summary
 .. _openjpeg: http://www.openjpeg.org/
 .. _zlib: http://www.zlib.net/
-.. _gumbo-parser: https://github.com/google/gumbo-parser
+.. _gumbo-parser: https://codeberg.org/gumbo-parser/gumbo-parser
 .. _FreeGLUT: http://freeglut.sourceforge.net/
 .. _curl: http://curl.haxx.se/
 .. _JPEG-XR reference: https://www.itu.int/rec/T-REC-T.835/


### PR DESCRIPTION
Hello, mupdf developers. Thank you for this cool project!

I'd like to propose an update of gumbo-parser dependency to 0.13.0. Since the last update of gumbo in the original Google's repository, many improvements have been introduced into the gumbo-parser project. Current version of gumbo in this repository falls behind in meeting HTML spec a lot and there are a couple of very serious bugs in it. Last year gumbo has received many improvements to the HTML spec compliance and now passes all html5lib-tests in this repo: https://codeberg.org/gumbo-parser/gumbo-parser

Many package repositories have already picked up the gumbo from Codeberg, notably Alpine, Arch, Debian, Fedora, FreeBSD, Gentoo, Homebrew, NixOS, OpenBSD, Slackware, Ubuntu and so on.

I thought it'd be useful to notify you about the need to update, so here I am.

I'm the new gumbo-parser maintainer, by the way.

Best regards,

Grigory