### PR TITLE
Fix incorrect includes$(path) syntax in Android.mk

### DIFF
--- a/platform/java/Android.mk
+++ b/platform/java/Android.mk
@@ -179,7 +179,7 @@ LOCAL_CFLAGS += $(filter-out -I%,$(OPENJPEG_CFLAGS) $(OPENJPEG_BUILD_CFLAGS))
 LOCAL_CFLAGS += $(MUPDF_EXTRA_CFLAGS)
 include $(BUILD_STATIC_LIBRARY)
 
-includes $(CLEAR_VARS)
+include $(CLEAR_VARS)
 LOCAL_MODULE += mupdf_thirdparty_brotli
 LOCAL_SRC_FILES += $(patsubst %,$(MUPDF_PATH)/%,$(BROTLI_SRC))
 LOCAL_C_INCLUDES += $(patsubst -I%,$(MUPDF_PATH)/%,$(filter -I%,$(BROTLI_CFLAGS) $(BROTLI_BUILD_CFLAGS)))


### PR DESCRIPTION
### Fix incorrect include syntax in Android.mk

#### Problem:
- The Android build script in `platform/java/Android.mk` had a typo: `includes$(path)` instead of `include $(path)`.
- This caused `ndk-build` to fail, preventing successful compilation of MuPDF for Android.

#### Fix Implemented:
- Corrected the syntax from `includes$(path)` → `include $(path)`.
- Ensured `ndk-build` correctly includes dependencies.

#### Impact:
- Fixes Android build errors.
- No changes to functionality—only a **build script fix**.

#### Testing:
- Successfully built MuPDF for Android using `ndk-build`.
- Verified that all required dependencies are included correctly.