### PR TITLE
scripts: add a way to provide libclang include dirs externally

### DIFF
--- a/scripts/wrap/cpp.py
+++ b/scripts/wrap/cpp.py
@@ -6,6 +6,7 @@ import io
 import os
 import pickle
 import re
+import shlex
 import textwrap
 
 import jlib
@@ -5311,6 +5312,14 @@ def cpp_source(
                 '-D', 'MUPDF_WRAP_LIBCLANG',
                 '-D', 'FZ_FUNCTION=',
                 ]
+
+        # In some circumstances (e.g. when cross-compiling when
+        # libclang doesn't have the right include directories by
+        # default) the includes are provided externally:
+        libclang_args = os.environ.get('MUPDF_LIBCLANG_ARGS', '')
+        if libclang_args:
+            args += shlex.split(libclang_args)
+
         tu = index.parse(
                 temp_h,
                 args = args,


### PR DESCRIPTION
When cross-compiling, libclang doesn't necessarily have the right include directories configured by default.
See for example: https://bugs.ghostscript.com/show_bug.cgi?id=708041

Since we also have no way to figure out the right include directories from our scripts, add a new environment variable that can be used to provide them externally.