### PR TITLE
fix mode for shared libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ install-headers:
 install-libs: libs install-headers
 	install -d $(DESTDIR)$(libdir)
 ifeq ($(shared),yes)
-	install -m 644 $(OUT)/libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION)
+	install -m $(SO_INSTALL_MODE) $(OUT)/libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION)
   ifneq ($(OS),OpenBSD)
 	ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION_MAJOR)
 	ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)


### PR DESCRIPTION
Among the many different changes squashed into
97d6e5d93 ("Spring cleaning of makefile.", 2025-02-25), obeying SO_INSTALL_MODE got lost for libmupdf.so.

Restore the previous behaviour.

Some automatic dependency generators depend on proper mode bits for shared libs, in particular when building on RHEL9 and the like.