### PR TITLE
murun: Remove unused resource stack causing NULL pointer read

### DIFF
--- a/source/tools/murun.c
+++ b/source/tools/murun.c
@@ -2051,7 +2051,6 @@ typedef struct
 {
 	pdf_processor super;
 	js_State *J;
-	resources_stack *rstack;
 	int extgstate;
 } pdf_js_processor;
 
@@ -2673,8 +2672,7 @@ static void js_proc_Do_form(fz_context *ctx, pdf_processor *proc, const char *na
 	PROC_BEGIN("op_Do_form");
 	js_pushstring(J, name);
 	ffi_pushobj(J, pdf_keep_obj(ctx, xobj));
-	ffi_pushobj(J, pdf_keep_obj(ctx, ((pdf_js_processor*)proc)->rstack->resources));
-	PROC_END(3);
+	PROC_END(2);
 }
 
 static void js_proc_MP(fz_context *ctx, pdf_processor *proc, const char *tag)
@@ -2739,25 +2737,12 @@ static pdf_obj *js_proc_pop_resources(fz_context *ctx, pdf_processor *proc)
 	return NULL;
 }
 
-static void js_proc_drop(fz_context *ctx, pdf_processor *proc)
-{
-	pdf_js_processor *pr = (pdf_js_processor *)proc;
-
-	while (pr->rstack)
-	{
-		resources_stack *stk = pr->rstack;
-		pr->rstack = stk->next;
-		pdf_drop_obj(ctx, stk->resources);
-		fz_free(ctx, stk);
-	}
-}
-
 static pdf_processor *new_js_processor(fz_context *ctx, js_State *J)
 {
 	pdf_js_processor *proc = pdf_new_processor(ctx, sizeof *proc);
 
 	proc->super.close_processor = NULL;
-	proc->super.drop_processor = js_proc_drop;
+	proc->super.drop_processor = NULL;
 
 	proc->super.push_resources = js_proc_push_resources;
 	proc->super.pop_resources = js_proc_pop_resources;


### PR DESCRIPTION
This is a simple bugfix: `mutool run` had a stack for PDF objects that was only being read from, not written to. This caused a NULL/garbage pointer read.

There were two ways this could be fixed, in my mind:

- Actually inserting pdf objects into the stack
- Removing the whole thing;

I picked the 2nd option because:

- It's simpler
- When we create PDF objects to pass to JS (`ffi_pushobj`), we already register functions to drop them. So I believe there's no need for the cleanup that existed before.

Below, there's a simple case to reproduce the bug:

### Reproducing

- Download [blank-form.pdf](https://github.com/user-attachments/files/19523528/blank-form.pdf) or any PDF with a XForm Object.
- Run `mutool run bug.js blank-form.pdf`

bug.js:
```js
function main() {
  var input = Document.openDocument(scriptArgs[0]);

  for (var i = 0; i < input.countPages(); i++) {
    var page = input.loadPage(i);
    page.process({
      op_Do_form: function () {
        print("Hello from JS!");
      },
    });
  }
}

if (scriptArgs.length !== 1) {
  print("usage: mutool run input.pdf");
} else {
  main();
}
```

#### Expected output

The program prints `Hello from JS!` for each Form XObject.

#### Actual output

The program segfaults.