### PR TITLE
Treat CRLF as a single newline

### DIFF
--- a/source/pdf/pdf-appearance.c
+++ b/source/pdf/pdf-appearance.c
@@ -1936,6 +1936,9 @@ write_string_with_quadding(fz_context *ctx, fz_buffer *buf,
 				write_string(ctx, buf, lang, font, fontname, size, a, b-1);
 			else
 				write_string(ctx, buf, lang, font, fontname, size, a, b);
+			// If \r followed by \n, skip the \n; \r\n is a single newline not two.
+			if (b[-1] == '\r' && b[0] == '\n')
+				 ++b;
 			a = b;
 			px = x;
 		}
@@ -2073,6 +2076,9 @@ layout_string_with_quadding(fz_context *ctx, fz_layout_block *out,
 				layout_string(ctx, out, lang, font, size, xorig+x, y, a, b);
 				add_line_at_end = 0;
 			}
+			// If \r followed by \n, skip the \n; \r\n is a single newline not two.
+			if (b[-1] == '\r' && b[0] == '\n')
+				++b;
 			a = b;
 			y -= lineheight;
 		}


### PR DESCRIPTION
Fix handling of \r\n (CRLF) in a text string.  A CARRIAGE RETURN followed immediately by a LINE FEED is a single newline, not two.