### PR TITLE
Add sanitize mode for stripping invisible text

### DIFF
--- a/include/mupdf/pdf/document.h
+++ b/include/mupdf/pdf/document.h
@@ -777,6 +777,7 @@ typedef struct
 	int do_use_objstms; /* Use objstms if possible */
 	int compression_effort; /* 0 for default. 100 = max, 1 = min. */
 	int do_labels; /* Add labels to each object showing how it can be reached from the Root. */
+	int do_strip_invisible_text; /* Strip invisible text, requires sanitize. */
 } pdf_write_options;
 
 FZ_DATA extern const pdf_write_options pdf_default_write_options;

--- a/source/tools/pdfclean.c
+++ b/source/tools/pdfclean.c
@@ -134,7 +134,7 @@ int pdfclean_main(int argc, char **argv)
 	opts.write = pdf_default_write_options;
 	opts.write.dont_regenerate_id = 1;
 
-	while ((c = fz_getopt_long(argc, argv, "ade:fgilmp:stcvzDAE:LO:U:P:SZ", longopts)) != -1)
+	while ((c = fz_getopt_long(argc, argv, "ade:fgiIlmp:stcvzDAE:LO:U:P:SZ", longopts)) != -1)
 	{
 		switch (c)
 		{
@@ -144,6 +144,7 @@ int pdfclean_main(int argc, char **argv)
 		case 'z': opts.write.do_compress += 1; break;
 		case 'f': opts.write.do_compress_fonts += 1; break;
 		case 'i': opts.write.do_compress_images += 1; break;
+		case 'I': opts.write.do_strip_invisible_text += 1; break;
 		case 'a': opts.write.do_ascii += 1; break;
 		case 'e': opts.write.compression_effort = fz_atoi(fz_optarg); break;
 		case 'g': opts.write.do_garbage += 1; break;


### PR DESCRIPTION
OCR processes typically produce text objects with text render mode 3, so this option allows stripping OCR layers for recreating them. This can also simplify documents for print processing without visual impact.