### PR TITLE
Fix incorrect format specifier in "pdf_page_label" method

### DIFF
--- a/source/pdf/pdf-page.c
+++ b/source/pdf/pdf-page.c
@@ -1991,7 +1991,7 @@ pdf_page_label(fz_context *ctx, pdf_document *doc, int index, char *buf, size_t 
 	if (range.label)
 		pdf_format_page_label(ctx, index - range.offset, range.label, buf, size);
 	else
-		fz_snprintf(buf, size, "%z", index + 1);
+		fz_snprintf(buf, size, "%d", index + 1);
 }
 
 void


### PR DESCRIPTION
`"%z"` format specifier is incorrect for argument of `int` type.
The regression was introduced in https://github.com/ArtifexSoftware/mupdf/commit/6c3e69741113f060af0aafe04f74ef93a23c987e.