### PR TITLE
Use absolute URLs for submodules improve fork cloneability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,83 +1,83 @@
 [submodule "thirdparty/jbig2dec"]
 	path = thirdparty/jbig2dec
-	url = ../jbig2dec.git
+	url = https://github.com/ArtifexSoftware/jbig2dec.git
 	shallow = true
 [submodule "thirdparty/mujs"]
 	path = thirdparty/mujs
-	url = ../mujs.git
+	url = https://github.com/ccxvii/mujs.git
 	shallow = true
 [submodule "thirdparty/freetype"]
 	path = thirdparty/freetype
-	url = ../thirdparty-freetype2.git
+	url = https://gitlab.freedesktop.org/freetype/freetype.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/gumbo-parser"]
 	path = thirdparty/gumbo-parser
-	url = ../thirdparty-gumbo-parser.git
+	url = https://github.com/google/gumbo-parser.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/harfbuzz"]
 	path = thirdparty/harfbuzz
-	url = ../thirdparty-harfbuzz.git
+	url = https://github.com/harfbuzz/harfbuzz.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/jpeg"]
 	path = thirdparty/libjpeg
-	url = ../thirdparty-libjpeg.git
+	url = https://github.com/libjpeg-turbo/libjpeg-turbo.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/lcms2"]
 	path = thirdparty/lcms2
-	url = ../thirdparty-lcms2.git
+	url = https://github.com/mm2/Little-CMS.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/openjpeg"]
 	path = thirdparty/openjpeg
-	url = ../thirdparty-openjpeg.git
+	url = https://github.com/uclouvain/openjpeg.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/zlib"]
 	path = thirdparty/zlib
-	url = ../thirdparty-zlib.git
+	url = https://github.com/madler/zlib.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/curl"]
 	path = thirdparty/curl
-	url = ../thirdparty-curl.git
+	url = https://github.com/curl/curl.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/freeglut"]
 	path = thirdparty/freeglut
-	url = ../thirdparty-freeglut.git
+	url = https://github.com/ArtifexSoftware/freeglut.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/tesseract"]
 	path = thirdparty/tesseract
-	url = ../thirdparty-tesseract.git
+	url = https://github.com/tesseract-ocr/tesseract.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/leptonica"]
 	path = thirdparty/leptonica
-	url = ../thirdparty-leptonica.git
+	url = https://github.com/DanBloomberg/leptonica.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/extract"]
 	path = thirdparty/extract
-	url = ../extract.git
+	url = https://github.com/ArtifexSoftware/extract.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/zxing-cpp"]
 	path = thirdparty/zxing-cpp
-	url = ../thirdparty-zxing-cpp.git
+	url = https://github.com/zxing-cpp/zxing-cpp.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/zint"]
 	path = thirdparty/zint
-	url = ../thirdparty-zint.git
+	url = https://github.com/zint/zint.git
 	branch = artifex
 	shallow = true
 [submodule "thirdparty/brotli"]
 	path = thirdparty/brotli
-	url = ../thirdparty-brotli.git
+	url = https://github.com/google/brotli.git
 	branch = artifex
 	shallow = true


### PR DESCRIPTION
This change replaces namespace-relative submodule URLs with explicit upstream URLs.

Rationale:
The current relative URLs work inside the upstream repository namespace, but they can break `git clone --recurse-submodules` for ordinary public forks unless all sibling submodule repositories also exist under the forker account or organization.

This does not change MuPDF functionality.
It only improves clone behavior and reduces friction for fork-based workflows, including GitHub Desktop and recursive clone usage outside the upstream namespace.
