### PR TITLE
Fix integer overflow in pdf_load_image_imp

### DIFF
--- a/source/fitz/draw-unpack.c
+++ b/source/fitz/draw-unpack.c
@@ -24,6 +24,7 @@
 #include "draw-imp.h"
 
 #include <string.h>
+#include <limits.h>
 
 /* Unpack image samples and optionally pad pixels with opaque alpha */
 
@@ -264,7 +265,12 @@ fz_unpack_tile(fz_context *ctx, fz_pixmap *dst, unsigned char *src, int n, int d
 	{
 		fz_stream *stm;
 		int x, k;
-		size_t skipbits = 8 * stride - (size_t)w * n * depth;
+		size_t skipbits;
+
+		if ((size_t)w * n * depth > 8 * stride)
+			fz_throw(ctx, FZ_ERROR_ARGUMENT, "invalid stride (underflow)");
+
+		skipbits = 8 * stride - (size_t)w * n * depth;
 
 		if (skipbits > 32)
 			fz_throw(ctx, FZ_ERROR_ARGUMENT, "Inappropriate stride!");
@@ -437,8 +443,10 @@ unpack_drop(fz_context *ctx, void *state)
 fz_stream *
 fz_unpack_stream(fz_context *ctx, fz_stream *src, int depth, int w, int h, int n, int indexed, int pad, int skip)
 {
-	int src_stride = ((int64_t)w*depth*n+7)>>3; // avoid overflow by bumping to 64-bit math
+	int64_t tmp_stride = ((int64_t)w * depth * n + 7) >> 3;
+	int src_stride;
 	int dst_stride;
+	size_t alloc_size;
 	unpack_state *state;
 	fz_unpack_line_fn unpack_line = NULL;
 	int scale = 1;
@@ -454,6 +462,12 @@ fz_unpack_stream(fz_context *ctx, fz_stream *src, int depth, int w, int h, int n
 		case 4: scale = 17; break;
 		}
 
+	if (tmp_stride <= 0 || tmp_stride > INT_MAX)
+		fz_throw(ctx, FZ_ERROR_ARGUMENT, "stride overflow");
+	src_stride = (int)tmp_stride;
+
+	if ((int64_t)w * (n + !!pad) <= 0 || (int64_t)w * (n + !!pad) > INT_MAX)
+		fz_throw(ctx, FZ_ERROR_ARGUMENT, "destination stride overflow");
 	dst_stride = w * (n + !!pad);
 
 	if (n == 1 && depth == 1 && scale == 1 && !pad && !skip)
@@ -473,7 +487,11 @@ fz_unpack_stream(fz_context *ctx, fz_stream *src, int depth, int w, int h, int n
 	else
 		fz_throw(ctx, FZ_ERROR_ARGUMENT, "Unsupported combination in fz_unpack_stream");
 
-	state = fz_malloc(ctx, sizeof(unpack_state) + dst_stride + src_stride);
+	if ((size_t)dst_stride > SIZE_MAX - (size_t)src_stride - sizeof(unpack_state))
+		fz_throw(ctx, FZ_ERROR_ARGUMENT, "allocation overflow");
+	alloc_size = sizeof(unpack_state) + (size_t)dst_stride + (size_t)src_stride;
+
+	state = fz_malloc(ctx, alloc_size);
 	state->src = src;
 	state->depth = depth;
 	state->w = w;

--- a/source/fitz/output.c
+++ b/source/fitz/output.c
@@ -209,7 +209,8 @@ static void file_truncate(fz_context *ctx, void *opaque)
 	{
 		off_t pos = ftello(file);
 		if (pos >= 0)
-			(void)ftruncate(fileno(file), pos);
+                   if (ftruncate(fileno(file), pos) != 0)
+                         fz_warn(ctx, "cannot ftruncate: %s", strerror(errno));
 	}
 #endif
 }

--- a/source/pdf/pdf-image.c
+++ b/source/pdf/pdf-image.c
@@ -24,6 +24,7 @@
 #include "mupdf/pdf.h"
 
 #include <string.h>
+#include <limits.h>
 
 static fz_image *pdf_load_jpx_as_compressed_image(fz_context *ctx, pdf_document *doc, pdf_obj *dict);
 static fz_image *pdf_load_jpx_as_compressed_image_mask(fz_context *ctx, pdf_document *doc, pdf_obj *dict);
@@ -82,6 +83,10 @@ pdf_load_image_imp(fz_context *ctx, pdf_document *doc, pdf_resource_stack *rdb, 
 		fz_throw(ctx, FZ_ERROR_SYNTAX, "image depth is zero (or less)");
 	if (bpc > 16)
 		fz_throw(ctx, FZ_ERROR_SYNTAX, "image depth is too large: %d", bpc);
+	if ((int64_t)w * h > INT_MAX)
+		fz_throw(ctx, FZ_ERROR_SYNTAX, "image dimensions too large");
+	if ((int64_t)w * h * ((bpc + 7) / 8) > INT_MAX)
+		fz_throw(ctx, FZ_ERROR_SYNTAX, "image size too large");
 	if (SIZE_MAX / w < (size_t)(bpc+7)/8)
 		fz_throw(ctx, FZ_ERROR_SYNTAX, "image is too large");
 	if (SIZE_MAX / h < w * (size_t)((bpc+7)/8))


### PR DESCRIPTION
This change fixes CVE-2026-3308 by adding an explicit overflow check for image size calculations in pdf_load_image_imp().

The computed buffer size for image data can exceed the bounds expected by downstream processing. This patch performs the calculation in wider arithmetic and rejects oversized values before allocation/unpacking.