### PR TITLE
replace freeglut with glfw+client side decorations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ $(OUT)/platform/x11/curl/%.o : platform/x11/%.c
 	$(CC_CMD) $(WARNING_CFLAGS) $(X11_CFLAGS) $(CURL_CFLAGS)
 
 $(OUT)/platform/gl/%.o : platform/gl/%.c
-	$(CC_CMD) $(WARNING_CFLAGS) $(THIRD_CFLAGS) $(THIRD_GLUT_CFLAGS)
+	$(CC_CMD) $(WARNING_CFLAGS) $(THIRD_CFLAGS) $(GLFW_CFLAGS)
 
 ifeq ($(HAVE_OBJCOPY),yes)
   $(OUT)/source/fitz/noto.o : source/fitz/noto.c
@@ -171,8 +171,6 @@ $(OUT)/platform/%.o : platform/%.c
 THIRD_OBJ := $(THIRD_SRC:%.c=$(OUT)/%.o)
 THIRD_OBJ := $(THIRD_OBJ:%.cc=$(OUT)/%.o)
 THIRD_OBJ := $(THIRD_OBJ:%.cpp=$(OUT)/%.o)
-
-THIRD_GLUT_OBJ := $(THIRD_GLUT_SRC:%.c=$(OUT)/%.o)
 
 MUPDF_SRC := $(sort $(wildcard source/fitz/*.c))
 MUPDF_SRC += $(sort $(wildcard source/fitz/*.cpp))
@@ -351,11 +349,6 @@ else
   $(THIRD_LIB) : $(THIRD_OBJ)
 endif
 
-ifneq ($(USE_SYSTEM_GLUT),yes)
-  THIRD_GLUT_LIB = $(OUT)/libmupdf-glut.a
-  $(THIRD_GLUT_LIB) : $(THIRD_GLUT_OBJ)
-endif
-
 THREAD_LIB = $(OUT)/libmupdf-threads.a
 $(THREAD_LIB) : $(THREAD_OBJ)
 
@@ -385,13 +378,13 @@ $(MURASTER_EXE) : $(MURASTER_OBJ) $(MUPDF_LIB) $(THIRD_LIB) $(PKCS7_LIB) $(THREA
 	$(LINK_CMD) $(THIRD_LIBS) $(THREADING_LIBS) $(LIBCRYPTO_LIBS)
 EXTRA_TOOL_APPS += $(MURASTER_EXE)
 
-ifeq ($(HAVE_GLUT),yes)
-  MUVIEW_GLUT_SRC += $(sort $(wildcard platform/gl/*.c))
-  MUVIEW_GLUT_OBJ := $(MUVIEW_GLUT_SRC:%.c=$(OUT)/%.o)
-  MUVIEW_GLUT_EXE := $(OUT)/mupdf-gl
-  $(MUVIEW_GLUT_EXE) : $(MUVIEW_GLUT_OBJ) $(MUPDF_LIB) $(THIRD_LIB) $(THIRD_GLUT_LIB) $(PKCS7_LIB)
-	$(LINK_CMD) $(THIRD_LIBS) $(LIBCRYPTO_LIBS) $(THIRD_GLUT_LIBS)
-  VIEW_APPS += $(MUVIEW_GLUT_EXE)
+ifeq ($(HAVE_GLFW),yes)
+  MUVIEW_GLFW_SRC += $(sort $(wildcard platform/gl/*.c))
+  MUVIEW_GLFW_OBJ := $(MUVIEW_GLFW_SRC:%.c=$(OUT)/%.o)
+  MUVIEW_GLFW_EXE := $(OUT)/mupdf-gl
+  $(MUVIEW_GLFW_EXE) : $(MUVIEW_GLFW_OBJ) $(MUPDF_LIB) $(THIRD_LIB) $(PKCS7_LIB)
+	$(LINK_CMD) $(EXE_LDFLAGS) $(THIRD_LIBS) $(LIBCRYPTO_LIBS) $(GLFW_LIBS)
+  VIEW_APPS += $(MUVIEW_GLFW_EXE)
 endif
 
 ifeq ($(HAVE_X11),yes)
@@ -426,10 +419,9 @@ endif
 -include $(PKCS7_OBJ:%.o=%.d)
 -include $(THREAD_OBJ:%.o=%.d)
 -include $(THIRD_OBJ:%.o=%.d)
--include $(THIRD_GLUT_OBJ:%.o=%.d)
 
 -include $(MUTOOL_OBJ:%.o=%.d)
--include $(MUVIEW_GLUT_OBJ:%.o=%.d)
+-include $(MUVIEW_GLFW_OBJ:%.o=%.d)
 -include $(MUVIEW_X11_OBJ:%.o=%.d)
 
 -include $(MURASTER_OBJ:%.o=%.d)
@@ -470,7 +462,6 @@ pydir ?= $(shell python3 -c "import sysconfig; print(sysconfig.get_path('platlib
 SO_INSTALL_MODE ?= 644
 
 third: $(THIRD_LIB)
-extra-libs: $(THIRD_GLUT_LIB)
 libs: $(MUPDF_LIB) $(THIRD_LIB) $(COMMERCIAL_LIBS)
 commercial-libs: $(COMMERCIAL_LIBS)
 tools: $(TOOL_APPS)

--- a/Makerules
+++ b/Makerules
@@ -217,9 +217,9 @@ ifneq "$(CLUSTER)" ""
 endif
 
 ifeq ($(OS),Darwin)
-  HAVE_GLUT := yes
-  SYS_GLUT_CFLAGS := -Wno-deprecated-declarations
-  SYS_GLUT_LIBS := -framework GLUT -framework OpenGL
+  HAVE_GLFW := yes
+  SYS_GLFW_CFLAGS :=
+  SYS_GLFW_LIBS := -lglfw -framework OpenGL
   CC = xcrun cc
   AR = xcrun ar
   LD = xcrun ld
@@ -311,19 +311,14 @@ else
     SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
   endif
 
-  ifeq ($(HAVE_GLUT),)
-    HAVE_GLUT := $(shell pkg-config --exists gl x11 xrandr && echo yes)
+  ifeq ($(HAVE_GLFW),)
+    HAVE_GLFW := $(shell pkg-config --exists glfw3 gl && echo yes)
   endif
-  ifeq ($(HAVE_GLUT),yes)
-    SYS_GL_CFLAGS := $(shell pkg-config --cflags gl x11 xrandr)
-    SYS_GL_LIBS := $(shell pkg-config --libs gl x11 xrandr)
-    ifeq ($(shell pkg-config --exists glut && echo yes),yes)
-      SYS_GLUT_CFLAGS := $(shell pkg-config --cflags glut)
-      SYS_GLUT_LIBS := $(shell pkg-config --libs glut)
-    else
-      SYS_GLUT_CFLAGS :=
-      SYS_GLUT_LIBS := -lglut
-    endif
+  ifeq ($(HAVE_GLFW),yes)
+    SYS_GLFW_CFLAGS := $(shell pkg-config --cflags glfw3)
+    SYS_GLFW_LIBS := $(shell pkg-config --libs glfw3)
+    SYS_GL_CFLAGS := $(shell pkg-config --cflags gl)
+    SYS_GL_LIBS := $(shell pkg-config --libs gl)
   endif
 
   ifeq ($(HAVE_X11),)
@@ -363,7 +358,7 @@ ifeq "$(OS)" "wasm"
   CC = emcc
   CXX = em++
   AR = emar
-  HAVE_GLUT=no
+  HAVE_GLFW=no
   HAVE_X11=no
   HAVE_OBJCOPY=no
   HAVE_LIBCRYPTO=no
@@ -377,7 +372,7 @@ ifeq "$(OS)" "wasm-mt"
   CC = emcc
   CXX = em++
   AR = emar
-  HAVE_GLUT=no
+  HAVE_GLFW=no
   HAVE_X11=no
   HAVE_OBJCOPY=no
   HAVE_LIBCRYPTO=no
@@ -391,7 +386,7 @@ ifeq "$(OS)" "pyodide"
   build_prefix += $(OS)/
   # We use the provided $CC and $CXX.
   AR = emar
-  HAVE_GLUT=no
+  HAVE_GLFW=no
   HAVE_X11=no
   HAVE_OBJCOPY=no
   HAVE_LIBCRYPTO=no

--- a/Makethird
+++ b/Makethird
@@ -11,16 +11,11 @@ ifeq ($(USE_SYSTEM_LIBS),yes)
   USE_SYSTEM_MUJS ?= no # not available
   USE_SYSTEM_OPENJPEG ?= yes
   USE_SYSTEM_ZLIB ?= yes
-  USE_SYSTEM_GLUT ?= yes
   USE_SYSTEM_CURL ?= yes
   USE_SYSTEM_LEPTONICA ?= yes
   USE_SYSTEM_TESSERACT ?= yes
   USE_SYSTEM_ZXINGCPP ?= yes
   USE_SYSTEM_BROTLI ?= yes
-endif
-
-ifeq ($(OS),MACOS)
-  USE_SYSTEM_GLUT := yes
 endif
 
 ifeq ($(OS),Linux)
@@ -245,17 +240,11 @@ $(OUT)/thirdparty/openjpeg/%.o: thirdparty/openjpeg/%.c
 	$(CC_CMD) $(LIB_CFLAGS) $(OPENJPEG_CFLAGS) $(OPENJPEG_BUILD_CFLAGS)
 endif
 
-# --- FreeGLUT ---
+# --- GLFW ---
 
-ifeq ($(USE_SYSTEM_GLUT),yes)
-  THIRD_GLUT_CFLAGS += $(SYS_GLUT_CFLAGS) $(SYS_GL_CFLAGS)
-  THIRD_GLUT_LIBS += $(SYS_GLUT_LIBS) $(SYS_GL_LIBS)
-else
-  THIRD_GLUT_CFLAGS += $(GLUT_CFLAGS) $(SYS_GL_CFLAGS)
-  THIRD_GLUT_LIBS += $(GLUT_LIBS) $(SYS_GL_LIBS)
-  THIRD_GLUT_SRC += $(GLUT_SRC)
-$(OUT)/thirdparty/freeglut/%.o: thirdparty/freeglut/%.c
-	$(CC_CMD) $(LIB_CFLAGS) $(GLUT_CFLAGS) $(GLUT_BUILD_CFLAGS)
+ifeq ($(HAVE_GLFW),yes)
+  GLFW_CFLAGS := $(SYS_GLFW_CFLAGS) $(SYS_GL_CFLAGS)
+  GLFW_LIBS := $(SYS_GLFW_LIBS) $(SYS_GL_LIBS)
 endif
 
 # --- cURL ---

--- a/platform/gl/gl-annotate.c
+++ b/platform/gl/gl-annotate.c
@@ -299,9 +299,9 @@ static void slow_operation_dialog(void)
 	if (ui_slow_operation_state.display == 0)
 	{
 		/* Run steps for 200ms or until we're done. */
-		start_time = glutGet(GLUT_ELAPSED_TIME);
+		start_time = (int)ui_get_time_ms();
 		while (!errored && ui_slow_operation_state.i >= 0 &&
-			glutGet(GLUT_ELAPSED_TIME) < start_time + 200)
+			(int)ui_get_time_ms() < start_time + 200)
 		{
 			errored = run_slow_operation_step(0);
 		}
@@ -311,7 +311,7 @@ static void slow_operation_dialog(void)
 		ui.dialog = NULL;
 
 	/* ... and trigger a redisplay */
-	glutPostRedisplay();
+	ui_invalidate();
 }
 
 static void
@@ -1996,7 +1996,7 @@ static void do_edit_polygon(fz_irect canvas_area, int close)
 	{
 		ui.hot = ui.selected_annot;
 		if (!ui.active || ui.active == ui.selected_annot)
-			ui.cursor = GLUT_CURSOR_CROSSHAIR;
+			ui.cursor = UI_CURSOR_CROSSHAIR;
 		if (!ui.active && ui.down)
 		{
 			ui.active = ui.selected_annot;
@@ -2057,7 +2057,7 @@ static void do_edit_ink(fz_irect canvas_area)
 	{
 		ui.hot = ui.selected_annot;
 		if (!ui.active || ui.active == ui.selected_annot)
-			ui.cursor = GLUT_CURSOR_CROSSHAIR;
+			ui.cursor = UI_CURSOR_CROSSHAIR;
 		if (!ui.active && ui.down)
 		{
 			ui.active = ui.selected_annot;
@@ -2128,7 +2128,7 @@ static void do_edit_quad_points(void)
 	{
 		ui.hot = ui.selected_annot;
 		if (!ui.active || ui.active == ui.selected_annot)
-			ui.cursor = GLUT_CURSOR_TEXT;
+			ui.cursor = UI_CURSOR_TEXT;
 		if (!ui.active && ui.down)
 		{
 			ui.active = ui.selected_annot;
@@ -2146,12 +2146,12 @@ static void do_edit_quad_points(void)
 		page_a = fz_transform_point(page_a, view_page_inv_ctm);
 		page_b = fz_transform_point(page_b, view_page_inv_ctm);
 
-		if (ui.mod == GLUT_ACTIVE_CTRL)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 			fz_snap_selection(ctx, page_text, &page_a, &page_b, FZ_SELECT_WORDS);
-		else if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 			fz_snap_selection(ctx, page_text, &page_a, &page_b, FZ_SELECT_LINES);
 
-		if (ui.mod == GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 		{
 			rect = fz_make_rect(
 					fz_min(page_a.x, page_b.x),
@@ -2205,7 +2205,7 @@ static void do_edit_quad_points(void)
 					pdf_add_annot_quad_point(ctx, ui.selected_annot, hits[i]);
 				}
 
-				if (ui.mod == GLUT_ACTIVE_SHIFT)
+				if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 					text = fz_copy_rectangle(ctx, page_text, rect, 0);
 				else
 					text = fz_copy_selection(ctx, page_text, page_a, page_b, 0);

--- a/platform/gl/gl-app.h
+++ b/platform/gl/gl-app.h
@@ -32,11 +32,22 @@ void win_install(void);
 #include "mupdf/ucdn.h"
 #include "mupdf/pdf.h" /* for pdf specifics and forms */
 
-#ifndef __APPLE__
-#include <GL/freeglut.h>
-#else
-#include <GLUT/glut.h>
-#endif
+#include <GLFW/glfw3.h>
+
+/* GLFW modifier key mappings */
+#define GLFW_MOD_ACTIVE_SHIFT GLFW_MOD_SHIFT
+#define GLFW_MOD_ACTIVE_CTRL  GLFW_MOD_CONTROL
+#define GLFW_MOD_ACTIVE_ALT   GLFW_MOD_ALT
+
+/* Cursor constants */
+enum
+{
+	UI_CURSOR_INHERIT = 0,
+	UI_CURSOR_TEXT,
+	UI_CURSOR_LEFT_RIGHT,
+	UI_CURSOR_UP_DOWN,
+	UI_CURSOR_CROSSHAIR,
+};
 
 /* UI */
 
@@ -130,10 +141,16 @@ struct ui
 
 extern struct ui ui;
 
+extern GLFWwindow *ui_window;
+double ui_get_time_ms(void);
+void ui_request_close(void);
+
 void ui_init_dpi(float override_ui_scale);
 void ui_init(int w, int h, const char *title);
 void ui_quit(void);
 void ui_invalidate(void);
+int ui_needs_redisplay(void);
+void check_timer(void);
 void ui_finish(void);
 
 void ui_set_clipboard(const char *buf);

--- a/platform/gl/gl-file.c
+++ b/platform/gl/gl-file.c
@@ -386,7 +386,7 @@ int ui_open_file(char *filename_, const char *label)
 				}
 				else
 				{
-					int click_time = glutGet(GLUT_ELAPSED_TIME);
+					int click_time = (int)ui_get_time_ms();
 					if (i == last_click_sel && click_time < last_click_time + 250)
 					{
 						fz_snprintf(filename_, PATH_MAX, "%s/%s", fc.curdir, name);

--- a/platform/gl/gl-input.c
+++ b/platform/gl/gl-input.c
@@ -233,18 +233,18 @@ static int ui_input_key(struct input *input, int multiline)
 	case 0:
 		return UI_INPUT_NONE;
 	case KEY_LEFT:
-		if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 		{
 			input->q = prev_word(input->q, input->text);
 		}
-		else if (ui.mod == GLUT_ACTIVE_CTRL)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 		{
 			if (input->p != input->q)
 				input->p = input->q = input->p < input->q ? input->p : input->q;
 			else
 				input->p = input->q = prev_word(input->q, input->text);
 		}
-		else if (ui.mod == GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 		{
 			if (input->q > input->text)
 				input->q = prev_char(input->q, input->text);
@@ -258,18 +258,18 @@ static int ui_input_key(struct input *input, int multiline)
 		}
 		break;
 	case KEY_RIGHT:
-		if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 		{
 			input->q = next_word(input->q, input->end);
 		}
-		else if (ui.mod == GLUT_ACTIVE_CTRL)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 		{
 			if (input->p != input->q)
 				input->p = input->q = input->p > input->q ? input->p : input->q;
 			else
 				input->p = input->q = next_word(input->q, input->end);
 		}
-		else if (ui.mod == GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 		{
 			if (input->q < input->end)
 				input->q = next_char(input->q);
@@ -283,39 +283,39 @@ static int ui_input_key(struct input *input, int multiline)
 		}
 		break;
 	case KEY_UP:
-		if (ui.mod & GLUT_ACTIVE_SHIFT)
+		if (ui.mod & GLFW_MOD_ACTIVE_SHIFT)
 			input->q = up_line(input->q, input->text);
 		else
 			input->p = input->q = up_line(input->p, input->text);
 		break;
 	case KEY_DOWN:
-		if (ui.mod & GLUT_ACTIVE_SHIFT)
+		if (ui.mod & GLFW_MOD_ACTIVE_SHIFT)
 			input->q = down_line(input->q, input->end);
 		else
 			input->p = input->q = down_line(input->q, input->end);
 		break;
 	case KEY_HOME:
-		if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 			input->q = input->text;
-		else if (ui.mod == GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 			input->q = home_line(input->q, input->text);
-		else if (ui.mod == GLUT_ACTIVE_CTRL)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 			input->p = input->q = input->text;
 		else if (ui.mod == 0)
 			input->p = input->q = home_line(input->p, input->text);
 		break;
 	case KEY_END:
-		if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 			input->q = input->end;
-		else if (ui.mod == GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 			input->q = end_line(input->q, input->end);
-		else if (ui.mod == GLUT_ACTIVE_CTRL)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 			input->p = input->q = input->end;
 		else if (ui.mod == 0)
 			input->p = input->q = end_line(input->p, input->end);
 		break;
 	case KEY_DELETE:
-		if (ui.mod == GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 		{
 			ui_do_cut(input);
 		}
@@ -349,7 +349,7 @@ static int ui_input_key(struct input *input, int multiline)
 		else if (input->p > input->text)
 		{
 			char *pp;
-			if (ui.mod == GLUT_ACTIVE_CTRL)
+			if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 				pp = prev_word(input->p, input->text);
 			else
 				pp = prev_char(input->p, input->text);
@@ -388,9 +388,9 @@ static int ui_input_key(struct input *input, int multiline)
 		ui_do_paste(input, multiline);
 		break;
 	case KEY_INSERT:
-		if (ui.mod == GLUT_ACTIVE_CTRL)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 			ui_do_copy(input);
-		if (ui.mod == GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 			ui_do_paste(input, multiline);
 		break;
 	default:
@@ -457,7 +457,7 @@ int ui_input(struct input *input, int width, int height)
 	{
 		ui.hot = input;
 		if (!ui.active || ui.active == input)
-			ui.cursor = GLUT_CURSOR_TEXT;
+			ui.cursor = UI_CURSOR_TEXT;
 		if (!ui.active && ui.down)
 		{
 			input->p = find_input_location(lines, n, ax, ay-sy, ui.x, ui.y);

--- a/platform/gl/gl-main.c
+++ b/platform/gl/gl-main.c
@@ -48,15 +48,6 @@ extern char **environ; /* see environ (7) */
 #include <direct.h> /* for getcwd */
 #endif
 
-#ifdef __APPLE__
-static void cleanup(void);
-void glutLeaveMainLoop(void)
-{
-	cleanup();
-	exit(0);
-}
-#endif
-
 fz_context *ctx = NULL;
 fz_colorspace *profile = NULL;
 pdf_document *pdf = NULL;
@@ -66,6 +57,7 @@ fz_matrix draw_page_ctm, view_page_ctm, view_page_inv_ctm;
 fz_rect page_bounds, draw_page_bounds, view_page_bounds;
 fz_irect view_page_area;
 char filename[PATH_MAX];
+char window_title[256] = "MuPDF";
 
 enum
 {
@@ -728,7 +720,7 @@ static void error_dialog(void)
 	ui_label("%C %s", 0x1f4a3, error_message); /* BOMB */
 	ui_layout(B, NONE, S, ui.padsize, ui.padsize);
 	if (ui_button("Quit") || ui.key == KEY_ENTER || ui.key == KEY_ESCAPE || ui.key == 'q')
-		glutLeaveMainLoop();
+		ui_request_close();
 	ui_dialog_end();
 }
 void ui_show_error_dialog(const char *fmt, ...)
@@ -773,7 +765,7 @@ static void quit_dialog(void)
 			do_save_pdf_file();
 		ui_spacer();
 		if (ui_button("Discard") || ui.key == 'q')
-			glutLeaveMainLoop();
+			ui_request_close();
 		ui_layout(L, NONE, S, 0, 0);
 		if (ui_button("Cancel") || ui.key == KEY_ESCAPE)
 			ui.dialog = NULL;
@@ -787,7 +779,7 @@ static void quit(void)
 	if (pdf && pdf_has_unsaved_changes(ctx, pdf))
 		ui.dialog = quit_dialog;
 	else
-		glutLeaveMainLoop();
+		ui_request_close();
 }
 
 static void reload_dialog(void)
@@ -887,8 +879,8 @@ void update_title(void)
 				currentpage.chapter + 1, nc,
 				currentpage.page + 1, fz_count_chapter_pages(ctx, doc, currentpage.chapter));
 	}
-	glutSetWindowTitle(buf);
-	glutSetIconTitle(buf);
+	glfwSetWindowTitle(ui_window, buf);
+	fz_strlcpy(window_title, buf, sizeof window_title);
 }
 
 void transform_page(void)
@@ -905,11 +897,14 @@ static void clear_selected_annot(void)
 	ui_select_annot(NULL);
 }
 
+static void clear_page_selection(void);
+
 void load_page(void)
 {
 	fz_irect area;
 
 	clear_selected_annot();
+	clear_page_selection();
 
 	if (trace_file)
 		trace_action("page = doc.loadPage(%d);\n", fz_page_number_from_location(ctx, doc, currentpage));
@@ -1555,12 +1550,77 @@ static void do_links(fz_link *link)
 	glDisable(GL_BLEND);
 }
 
+/* Persistent selection state for copy/paste support */
+static struct {
+	int active;          /* whether a persistent selection exists */
+	int is_rect;         /* rectangle vs text-flow selection */
+	fz_point page_a;     /* selection start in page coordinates */
+	fz_point page_b;     /* selection end in page coordinates */
+	fz_rect rect;        /* rectangle selection bounds */
+	fz_quad hits[1000];
+	int hit_count;
+} sel;
+
+static void clear_page_selection(void)
+{
+	sel.active = 0;
+	sel.hit_count = 0;
+}
+
+static void copy_page_selection(void)
+{
+	char *s;
+	if (!sel.active || !page_text)
+		return;
+#ifdef _WIN32
+	if (sel.is_rect)
+		s = fz_copy_rectangle(ctx, page_text, sel.rect, 1);
+	else
+		s = fz_copy_selection(ctx, page_text, sel.page_a, sel.page_b, 1);
+#else
+	if (sel.is_rect)
+		s = fz_copy_rectangle(ctx, page_text, sel.rect, 0);
+	else
+		s = fz_copy_selection(ctx, page_text, sel.page_a, sel.page_b, 0);
+#endif
+	ui_set_clipboard(s);
+	fz_free(ctx, s);
+}
+
+static void draw_selection_highlights(fz_quad *hits, int n)
+{
+	int i;
+	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+	glEnable(GL_BLEND);
+	glColor4f(0.0, 0.1, 0.4, 0.3f);
+
+	glBegin(GL_QUADS);
+	for (i = 0; i < n; ++i)
+	{
+		fz_quad thit = fz_transform_quad(hits[i], view_page_ctm);
+		glVertex2f(thit.ul.x, thit.ul.y);
+		glVertex2f(thit.ur.x, thit.ur.y);
+		glVertex2f(thit.lr.x, thit.lr.y);
+		glVertex2f(thit.ll.x, thit.ll.y);
+	}
+	glEnd();
+
+	glDisable(GL_BLEND);
+}
+
 static void do_page_selection(void)
 {
 	static fz_point pt = { 0, 0 };
 	static fz_quad hits[1000];
-	fz_rect rect;
-	int i, n;
+	int n;
+
+	/* Ctrl+C copies the persistent selection */
+	if (!ui.focus && ui.key == KEY_CTL_C && sel.active)
+	{
+		copy_page_selection();
+		ui.key = 0;
+		return;
+	}
 
 	if (ui_mouse_inside(view_page_area))
 	{
@@ -1571,70 +1631,66 @@ static void do_page_selection(void)
 			pt.x = ui.x;
 			pt.y = ui.y;
 		}
+		/* Left-click in page area clears the persistent selection */
+		if (!ui.active && ui.down)
+		{
+			clear_page_selection();
+		}
 	}
 
 	if (ui.active == &pt)
 	{
 		fz_point page_a = { pt.x, pt.y };
 		fz_point page_b = { ui.x, ui.y };
+		int is_rect = 0;
 
 		page_a = fz_transform_point(page_a, view_page_inv_ctm);
 		page_b = fz_transform_point(page_b, view_page_inv_ctm);
 
-		if (ui.mod == GLUT_ACTIVE_CTRL)
+		if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 			fz_snap_selection(ctx, page_text, &page_a, &page_b, FZ_SELECT_WORDS);
-		else if (ui.mod == GLUT_ACTIVE_CTRL + GLUT_ACTIVE_SHIFT)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL + GLFW_MOD_ACTIVE_SHIFT)
 			fz_snap_selection(ctx, page_text, &page_a, &page_b, FZ_SELECT_LINES);
 
-		if (ui.mod == GLUT_ACTIVE_SHIFT)
+		if (ui.mod == GLFW_MOD_ACTIVE_SHIFT)
 		{
-			rect = fz_make_rect(
+			fz_rect rect = fz_make_rect(
 					fz_min(page_a.x, page_b.x),
 					fz_min(page_a.y, page_b.y),
 					fz_max(page_a.x, page_b.x),
 					fz_max(page_a.y, page_b.y));
 			n = 1;
 			hits[0] = fz_quad_from_rect(rect);
+			is_rect = 1;
+
+			/* Save for persistent state */
+			sel.rect = rect;
 		}
 		else
 		{
 			n = fz_highlight_selection(ctx, page_text, page_a, page_b, hits, nelem(hits));
+			is_rect = 0;
 		}
 
-		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		glEnable(GL_BLEND);
-		glColor4f(0.0, 0.1, 0.4, 0.3f);
-
-		glBegin(GL_QUADS);
-		for (i = 0; i < n; ++i)
-		{
-			fz_quad thit = fz_transform_quad(hits[i], view_page_ctm);
-			glVertex2f(thit.ul.x, thit.ul.y);
-			glVertex2f(thit.ur.x, thit.ur.y);
-			glVertex2f(thit.lr.x, thit.lr.y);
-			glVertex2f(thit.ll.x, thit.ll.y);
-		}
-		glEnd();
-
-		glDisable(GL_BLEND);
+		draw_selection_highlights(hits, n);
 
 		if (!ui.right)
 		{
-			char *s;
-#ifdef _WIN32
-			if (ui.mod == GLUT_ACTIVE_SHIFT)
-				s = fz_copy_rectangle(ctx, page_text, rect, 1);
-			else
-				s = fz_copy_selection(ctx, page_text, page_a, page_b, 1);
-#else
-			if (ui.mod == GLUT_ACTIVE_SHIFT)
-				s = fz_copy_rectangle(ctx, page_text, rect, 0);
-			else
-				s = fz_copy_selection(ctx, page_text, page_a, page_b, 0);
-#endif
-			ui_set_clipboard(s);
-			fz_free(ctx, s);
+			/* Right mouse button released: persist the selection and copy */
+			sel.active = 1;
+			sel.is_rect = is_rect;
+			sel.page_a = page_a;
+			sel.page_b = page_b;
+			sel.hit_count = n < (int)nelem(sel.hits) ? n : (int)nelem(sel.hits);
+			memcpy(sel.hits, hits, sel.hit_count * sizeof(fz_quad));
+
+			copy_page_selection();
 		}
+	}
+	else if (sel.active && sel.hit_count > 0)
+	{
+		/* Draw persistent selection highlight */
+		draw_selection_highlights(sel.hits, sel.hit_count);
 	}
 }
 
@@ -1666,17 +1722,16 @@ static void toggle_fullscreen(void)
 	static int win_w = 100, win_h = 100;
 	if (!isfullscreen)
 	{
-		win_w = glutGet(GLUT_WINDOW_WIDTH);
-		win_h = glutGet(GLUT_WINDOW_HEIGHT);
-		win_x = glutGet(GLUT_WINDOW_X);
-		win_y = glutGet(GLUT_WINDOW_Y);
-		glutFullScreen();
+		glfwGetWindowSize(ui_window, &win_w, &win_h);
+		glfwGetWindowPos(ui_window, &win_x, &win_y);
+		GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+		const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+		glfwSetWindowMonitor(ui_window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
 		isfullscreen = 1;
 	}
 	else
 	{
-		glutPositionWindow(win_x, win_y);
-		glutReshapeWindow(win_w, win_h);
+		glfwSetWindowMonitor(ui_window, NULL, win_x, win_y, win_w, win_h, 0);
 		isfullscreen = 0;
 	}
 }
@@ -1699,7 +1754,7 @@ static void shrinkwrap(void)
 		h = screen_h;
 	if (isfullscreen)
 		toggle_fullscreen();
-	glutReshapeWindow(w, h);
+	glfwSetWindowSize(ui_window, w, h);
 }
 
 static struct input input_password;
@@ -1717,7 +1772,7 @@ static void password_dialog(void)
 		{
 			ui_layout(R, NONE, S, 0, 0);
 			if (ui_button("Cancel") || (!ui.focus && ui.key == KEY_ESCAPE))
-				glutLeaveMainLoop();
+				ui_request_close();
 			ui_spacer();
 			if (ui_button("Okay") || is == UI_INPUT_ACCEPT)
 			{
@@ -2369,7 +2424,7 @@ void do_console(void)
 
 static void do_app(void)
 {
-	if (ui.mod == GLUT_ACTIVE_ALT)
+	if (ui.mod == GLFW_MOD_ACTIVE_ALT)
 	{
 		if (ui.key == KEY_F4)
 			quit();
@@ -2834,6 +2889,61 @@ static void do_coord_tooltip(void)
 	tooltip = coord_tooltip;
 }
 
+void ui_draw_custom_titlebar(GLFWwindow *window)
+{
+	// Define a stable, unique memory address to act as the widget ID
+	static const void *close_btn_id = "close_btn";
+	static const char close_string[] = "🗙";
+
+	// 1. Dock to top, fill horizontally
+	ui_layout(T, X, NW, 0, 0);
+
+	// 2. Allocate the title bar (Height = lineheight + 16px padding)
+	fz_irect bar_area = ui_pack(0, ui.lineheight + 16);
+
+	// 3. Draw Background (Modern Dark Gray)
+	glColorHex(0x2E3440);
+	glRectf(bar_area.x0, bar_area.y0, bar_area.x1, bar_area.y1);
+
+	// 4. Draw Title Text (Force White)
+	int text_y = bar_area.y0 + 8; // Center the text vertically
+	glColorHex(0xFFFFFF);
+	ui_draw_string(bar_area.x0 + 12, text_y, window_title);
+
+	// 5. Draw Modern Flat Close Button
+	int btn_w = 46;
+	fz_irect close_area = fz_make_irect(bar_area.x1 - btn_w, bar_area.y0, bar_area.x1, bar_area.y1);
+
+	int hovered = ui_mouse_inside(close_area);
+	if (hovered)
+	{
+		ui.hot = close_btn_id;
+		if (!ui.active && ui.down)
+			ui.active = close_btn_id;
+	}
+
+	int pressed = (ui.hot == close_btn_id && ui.active == close_btn_id && ui.down);
+
+	// Flat Color Logic
+	if (pressed)
+		glColorHex(0x8B0000); // Dark Red when clicked
+	else if (hovered)
+		glColorHex(0xE81123); // Standard Bright Red when hovered
+	else
+		glColorHex(0x2E3440); // Match title bar when idle
+
+	glRectf(close_area.x0, close_area.y0, close_area.x1, close_area.y1);
+
+	// Draw the '🗙 ' perfectly centered inside the button
+	glColorHex(0xFFFFFF);
+	int x_width = ui_measure_string(close_string);
+	ui_draw_string(close_area.x0 + (btn_w - x_width) / 2, text_y, close_string);
+
+	// Trigger close on click release
+	if (ui.hot == close_btn_id && ui.active == close_btn_id && !ui.down)
+		glfwSetWindowShouldClose(window, GLFW_TRUE);
+}
+
 static void do_canvas(void)
 {
 	static int saved_scroll_x = 0;
@@ -2875,7 +2985,7 @@ static void do_canvas(void)
 			scroll_x -= ui.scroll_x * ui.lineheight * 3;
 			scroll_y -= ui.scroll_y * ui.lineheight * 3;
 		}
-		else if (ui.mod == GLUT_ACTIVE_CTRL)
+		else if (ui.mod == GLFW_MOD_ACTIVE_CTRL)
 		{
 			if (ui.scroll_y > 0) set_zoom(zoom_in(currentzoom), ui.x, ui.y);
 			if (ui.scroll_y < 0) set_zoom(zoom_out(currentzoom), ui.x, ui.y);
@@ -3020,7 +3130,7 @@ void do_main(void)
 {
 	if (search_active)
 	{
-		int start_time = glutGet(GLUT_ELAPSED_TIME);
+		int start_time = (int)ui_get_time_ms();
 
 		if (ui.key == KEY_ESCAPE)
 			search_active = 0;
@@ -3029,7 +3139,7 @@ void do_main(void)
 		ui.key = ui.mod = ui.plain = 0;
 		ui.down = ui.middle = ui.right = 0;
 
-		while (search_active && glutGet(GLUT_ELAPSED_TIME) < start_time + 200)
+		while (search_active && (int)ui_get_time_ms() < start_time + 200)
 		{
 			fz_try(ctx)
 			{
@@ -3076,7 +3186,7 @@ void do_main(void)
 
 		/* keep searching later */
 		if (search_active)
-			glutPostRedisplay();
+			ui_invalidate();
 	}
 
 	do_app();
@@ -3131,6 +3241,7 @@ void run_main_loop(void)
 	else
 		glClearColor(0.3f, 0.3f, 0.3f, 1);
 	ui_begin();
+	ui_draw_custom_titlebar(ui_window);
 	fz_try(ctx)
 	{
 		if (ui.dialog)
@@ -3187,7 +3298,7 @@ static void do_open_document_dialog(void)
 	{
 		ui.dialog = NULL;
 		if (filename[0] == 0)
-			glutLeaveMainLoop();
+			ui_request_close();
 		else
 		{
 			load_document();
@@ -3271,7 +3382,12 @@ int main(int argc, char **argv)
 	signal(SIGHUP, signal_handler);
 #endif
 
-	glutInit(&argc, argv);
+	glfwInitHint(GLFW_WAYLAND_LIBDECOR, GLFW_WAYLAND_DISABLE_LIBDECOR);
+	if (glfwInit() != GLFW_TRUE)
+	{
+		fprintf(stderr, "Failed to initialize GLFW\n");
+		exit(1);
+	}
 
 	while ((c = fz_getopt(argc, argv, "p:r:IW:H:S:U:XJb:A:B:C:T:Y:R:c:v")) != -1)
 	{
@@ -3299,8 +3415,15 @@ int main(int argc, char **argv)
 		}
 	}
 
-	screen_w = glutGet(GLUT_SCREEN_WIDTH) - SCREEN_FURNITURE_W;
-	screen_h = glutGet(GLUT_SCREEN_HEIGHT) - SCREEN_FURNITURE_H;
+	{
+		GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+		if (monitor)
+		{
+			const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+			screen_w = mode->width - SCREEN_FURNITURE_W;
+			screen_h = mode->height - SCREEN_FURNITURE_H;
+		}
+	}
 
 	ui_init_dpi(scale);
 
@@ -3428,7 +3551,23 @@ int main(int argc, char **argv)
 	console_h *= ui.lineheight;
 #endif
 
-	glutMainLoop();
+	ui_invalidate(); /* trigger first frame */
+
+	/* GLFW main loop */
+	while (!glfwWindowShouldClose(ui_window))
+	{
+		check_timer();
+
+		if (ui_needs_redisplay())
+		{
+			void (*old_dialog)(void) = ui.dialog;
+			run_main_loop();
+			if (ui.dialog != old_dialog)
+				ui_invalidate();
+		}
+
+		glfwWaitEventsTimeout(0.1);
+	}
 
 	cleanup();
 

--- a/platform/gl/gl-ui.c
+++ b/platform/gl/gl-ui.c
@@ -26,14 +26,22 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifndef FREEGLUT
-/* freeglut extension no-ops */
-void glutExit(void) {}
-void glutMouseWheelFunc(void *fn) {}
-void glutInitErrorFunc(void *fn) {}
-void glutInitWarningFunc(void *fn) {}
-#define glutSetOption(X,Y)
-#endif
+GLFWwindow *ui_window = NULL;
+
+static GLFWcursor *cursor_text = NULL;
+static GLFWcursor *cursor_hresize = NULL;
+static GLFWcursor *cursor_vresize = NULL;
+static GLFWcursor *cursor_crosshair = NULL;
+
+double ui_get_time_ms(void)
+{
+	return glfwGetTime() * 1000.0;
+}
+
+void ui_request_close(void)
+{
+	glfwSetWindowShouldClose(ui_window, GLFW_TRUE);
+}
 
 enum
 {
@@ -46,35 +54,15 @@ enum
 
 struct ui ui;
 
-#if defined(FREEGLUT) && (GLUT_API_VERSION >= 6)
-
 void ui_set_clipboard(const char *buf)
 {
-	glutSetClipboard(GLUT_PRIMARY, buf);
-	glutSetClipboard(GLUT_CLIPBOARD, buf);
+	glfwSetClipboardString(ui_window, buf);
 }
 
 const char *ui_get_clipboard(void)
 {
-	return glutGetClipboard(GLUT_CLIPBOARD);
+	return glfwGetClipboardString(ui_window);
 }
-
-#else
-
-static char *clipboard_buffer = NULL;
-
-void ui_set_clipboard(const char *buf)
-{
-	fz_free(ctx, clipboard_buffer);
-	clipboard_buffer = fz_strdup(ctx, buf);
-}
-
-const char *ui_get_clipboard(void)
-{
-	return clipboard_buffer;
-}
-
-#endif
 
 static const char *ogl_error_string(GLenum code)
 {
@@ -94,22 +82,10 @@ static const char *ogl_error_string(GLenum code)
 #undef CASE
 }
 
-static int has_ARB_texture_non_power_of_two = 1;
 static GLint max_texture_size = 8192;
 
 void ui_init_draw(void)
 {
-}
-
-static unsigned int next_power_of_two(unsigned int n)
-{
-	--n;
-	n |= n >> 1;
-	n |= n >> 2;
-	n |= n >> 4;
-	n |= n >> 8;
-	n |= n >> 16;
-	return ++n;
 }
 
 void ui_texture_from_pixmap(struct texture *tex, fz_pixmap *pix)
@@ -125,27 +101,12 @@ void ui_texture_from_pixmap(struct texture *tex, fz_pixmap *pix)
 	tex->w = pix->w;
 	tex->h = pix->h;
 
-	if (has_ARB_texture_non_power_of_two)
-	{
-		if (tex->w > max_texture_size || tex->h > max_texture_size)
-			fz_warn(ctx, "texture size (%d x %d) exceeds implementation limit (%d)", tex->w, tex->h, max_texture_size);
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex->w, tex->h, 0, pix->n == 4 ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, pix->samples);
-		tex->s = 1;
-		tex->t = 1;
-	}
-	else
-	{
-		int w2 = next_power_of_two(tex->w);
-		int h2 = next_power_of_two(tex->h);
-		if (w2 > max_texture_size || h2 > max_texture_size)
-			fz_warn(ctx, "texture size (%d x %d) exceeds implementation limit (%d)", w2, h2, max_texture_size);
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w2, h2, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, tex->w, tex->h, pix->n == 4 ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, pix->samples);
-		tex->s = (float) tex->w / w2;
-		tex->t = (float) tex->h / h2;
-	}
+	if (tex->w > max_texture_size || tex->h > max_texture_size)
+		fz_warn(ctx, "texture size (%d x %d) exceeds implementation limit (%d)", tex->w, tex->h, max_texture_size);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex->w, tex->h, 0, pix->n == 4 ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, pix->samples);
+	tex->s = 1;
+	tex->t = 1;
 }
 
 void ui_draw_image(struct texture *tex, float x, float y)
@@ -225,183 +186,196 @@ void ui_draw_ibevel_rect(fz_irect area, unsigned int fill, int depressed)
 	glRectf(area.x0+2, area.y0+2, area.x1-2, area.y1-2);
 }
 
-#if defined(FREEGLUT) && (GLUT_API_VERSION >= 6)
-static void on_keyboard(int key, int x, int y)
-#else
-static void on_keyboard(unsigned char key, int x, int y)
-#endif
+static int glfw_mods_to_ui(int mods)
 {
-#ifdef __APPLE__
-	/* Apple's GLUT has swapped DELETE and BACKSPACE */
-	if (key == 8)
-		key = 127;
-	else if (key == 127)
-		key = 8;
-#endif
-	ui.x = x;
-	ui.y = y;
-	ui.key = key;
-	ui.mod = glutGetModifiers();
-	ui.plain = !(ui.mod & ~GLUT_ACTIVE_SHIFT);
+	int m = 0;
+	if (mods & GLFW_MOD_SHIFT) m |= GLFW_MOD_ACTIVE_SHIFT;
+	if (mods & GLFW_MOD_CONTROL) m |= GLFW_MOD_ACTIVE_CTRL;
+	if (mods & GLFW_MOD_ALT) m |= GLFW_MOD_ACTIVE_ALT;
+	return m;
+}
+
+static void on_char(GLFWwindow *window, unsigned int codepoint)
+{
+	double mx, my;
+	glfwGetCursorPos(window, &mx, &my);
+	ui.x = (int)mx;
+	ui.y = (int)my;
+	ui.key = codepoint;
+	ui.mod = glfw_mods_to_ui(0);
+	ui.plain = 1;
 	run_main_loop();
 	ui.key = ui.plain = 0;
 	ui_invalidate(); // TODO: leave this to caller
 }
 
-static void on_special(int key, int x, int y)
+static void on_key(GLFWwindow *window, int key, int scancode, int action, int mods)
 {
-	ui.x = x;
-	ui.y = y;
-	ui.key = 0;
+	double mx, my;
+	int uikey = 0;
+
+	if (action == GLFW_RELEASE)
+		return;
+
+	glfwGetCursorPos(window, &mx, &my);
+	ui.x = (int)mx;
+	ui.y = (int)my;
 
 	switch (key)
 	{
-	case GLUT_KEY_INSERT: ui.key = KEY_INSERT; break;
-#ifdef GLUT_KEY_DELETE
-	case GLUT_KEY_DELETE: ui.key = KEY_DELETE; break;
-#endif
-	case GLUT_KEY_RIGHT: ui.key = KEY_RIGHT; break;
-	case GLUT_KEY_LEFT: ui.key = KEY_LEFT; break;
-	case GLUT_KEY_DOWN: ui.key = KEY_DOWN; break;
-	case GLUT_KEY_UP: ui.key = KEY_UP; break;
-	case GLUT_KEY_PAGE_UP: ui.key = KEY_PAGE_UP; break;
-	case GLUT_KEY_PAGE_DOWN: ui.key = KEY_PAGE_DOWN; break;
-	case GLUT_KEY_HOME: ui.key = KEY_HOME; break;
-	case GLUT_KEY_END: ui.key = KEY_END; break;
-	case GLUT_KEY_F1: ui.key = KEY_F1; break;
-	case GLUT_KEY_F2: ui.key = KEY_F2; break;
-	case GLUT_KEY_F3: ui.key = KEY_F3; break;
-	case GLUT_KEY_F4: ui.key = KEY_F4; break;
-	case GLUT_KEY_F5: ui.key = KEY_F5; break;
-	case GLUT_KEY_F6: ui.key = KEY_F6; break;
-	case GLUT_KEY_F7: ui.key = KEY_F7; break;
-	case GLUT_KEY_F8: ui.key = KEY_F8; break;
-	case GLUT_KEY_F9: ui.key = KEY_F9; break;
-	case GLUT_KEY_F10: ui.key = KEY_F10; break;
-	case GLUT_KEY_F11: ui.key = KEY_F11; break;
-	case GLUT_KEY_F12: ui.key = KEY_F12; break;
+	case GLFW_KEY_INSERT: uikey = KEY_INSERT; break;
+	case GLFW_KEY_DELETE: uikey = KEY_DELETE; break;
+	case GLFW_KEY_RIGHT: uikey = KEY_RIGHT; break;
+	case GLFW_KEY_LEFT: uikey = KEY_LEFT; break;
+	case GLFW_KEY_DOWN: uikey = KEY_DOWN; break;
+	case GLFW_KEY_UP: uikey = KEY_UP; break;
+	case GLFW_KEY_PAGE_UP: uikey = KEY_PAGE_UP; break;
+	case GLFW_KEY_PAGE_DOWN: uikey = KEY_PAGE_DOWN; break;
+	case GLFW_KEY_HOME: uikey = KEY_HOME; break;
+	case GLFW_KEY_END: uikey = KEY_END; break;
+	case GLFW_KEY_F1: uikey = KEY_F1; break;
+	case GLFW_KEY_F2: uikey = KEY_F2; break;
+	case GLFW_KEY_F3: uikey = KEY_F3; break;
+	case GLFW_KEY_F4: uikey = KEY_F4; break;
+	case GLFW_KEY_F5: uikey = KEY_F5; break;
+	case GLFW_KEY_F6: uikey = KEY_F6; break;
+	case GLFW_KEY_F7: uikey = KEY_F7; break;
+	case GLFW_KEY_F8: uikey = KEY_F8; break;
+	case GLFW_KEY_F9: uikey = KEY_F9; break;
+	case GLFW_KEY_F10: uikey = KEY_F10; break;
+	case GLFW_KEY_F11: uikey = KEY_F11; break;
+	case GLFW_KEY_F12: uikey = KEY_F12; break;
+	case GLFW_KEY_ESCAPE: uikey = KEY_ESCAPE; break;
+	case GLFW_KEY_ENTER: uikey = KEY_ENTER; break;
+	case GLFW_KEY_KP_ENTER: uikey = KEY_ENTER; break;
+	case GLFW_KEY_TAB: uikey = KEY_TAB; break;
+	case GLFW_KEY_BACKSPACE: uikey = KEY_BACKSPACE; break;
+	default:
+		/* Handle Ctrl+key combinations */
+		if ((mods & GLFW_MOD_CONTROL) && key >= GLFW_KEY_A && key <= GLFW_KEY_Z)
+		{
+			uikey = key - GLFW_KEY_A + 1; /* CTL_A=1, CTL_B=2, ... */
+		}
+		break;
 	}
 
-	if (ui.key)
+	if (uikey)
 	{
-		ui.mod = glutGetModifiers();
-		ui.plain = !(ui.mod & ~GLUT_ACTIVE_SHIFT);
+		ui.key = uikey;
+		ui.mod = glfw_mods_to_ui(mods);
+		ui.plain = !(ui.mod & ~GLFW_MOD_ACTIVE_SHIFT);
 		run_main_loop();
 		ui.key = ui.plain = 0;
 		ui_invalidate(); // TODO: leave this to caller
 	}
 }
 
-static void on_wheel(int wheel, int direction, int x, int y)
+static void on_scroll(GLFWwindow *window, double xoffset, double yoffset)
 {
-	ui.scroll_x = wheel == 1 ? direction : 0;
-	ui.scroll_y = wheel == 0 ? direction : 0;
-	ui.mod = glutGetModifiers();
+	ui.scroll_x = (int)xoffset;
+	ui.scroll_y = (int)yoffset;
+	ui.mod = 0;
+	if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+		glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+		ui.mod |= GLFW_MOD_ACTIVE_SHIFT;
+	if (glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+		glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS)
+		ui.mod |= GLFW_MOD_ACTIVE_CTRL;
+	if (glfwGetKey(window, GLFW_KEY_LEFT_ALT) == GLFW_PRESS ||
+		glfwGetKey(window, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS)
+		ui.mod |= GLFW_MOD_ACTIVE_ALT;
 	run_main_loop();
 	ui_invalidate(); // TODO: leave this to caller
 	ui.scroll_x = ui.scroll_y = 0;
 }
 
-static void on_mouse(int button, int action, int x, int y)
+static void on_mouse_button(GLFWwindow *window, int button, int action, int mods)
 {
-	ui.x = x;
-	ui.y = y;
-	if (action == GLUT_DOWN)
+	double mx, my;
+	glfwGetCursorPos(window, &mx, &my);
+	ui.x = (int)mx;
+	ui.y = (int)my;
+
+	if (action == GLFW_PRESS)
 	{
 		switch (button)
 		{
-		case GLUT_LEFT_BUTTON:
-			ui.down_x = x;
-			ui.down_y = y;
+		case GLFW_MOUSE_BUTTON_LEFT:
+			ui.down_x = ui.x;
+			ui.down_y = ui.y;
 			ui.down = 1;
 			break;
-		case GLUT_MIDDLE_BUTTON:
-			ui.middle_x = x;
-			ui.middle_y = y;
+		case GLFW_MOUSE_BUTTON_MIDDLE:
+			ui.middle_x = ui.x;
+			ui.middle_y = ui.y;
 			ui.middle = 1;
 			break;
-		case GLUT_RIGHT_BUTTON:
-			ui.right_x = x;
-			ui.right_y = y;
+		case GLFW_MOUSE_BUTTON_RIGHT:
+			ui.right_x = ui.x;
+			ui.right_y = ui.y;
 			ui.right = 1;
 			break;
-		case 3: on_wheel(0, 1, x, y); break;
-		case 4: on_wheel(0, -1, x, y); break;
-		case 5: on_wheel(1, 1, x, y); break;
-		case 6: on_wheel(1, -1, x, y); break;
 		}
 	}
-	else if (action == GLUT_UP)
+	else if (action == GLFW_RELEASE)
 	{
 		switch (button)
 		{
-		case GLUT_LEFT_BUTTON: ui.down = 0; break;
-		case GLUT_MIDDLE_BUTTON: ui.middle = 0; break;
-		case GLUT_RIGHT_BUTTON: ui.right = 0; break;
+		case GLFW_MOUSE_BUTTON_LEFT: ui.down = 0; break;
+		case GLFW_MOUSE_BUTTON_MIDDLE: ui.middle = 0; break;
+		case GLFW_MOUSE_BUTTON_RIGHT: ui.right = 0; break;
 		}
 	}
-	ui.mod = glutGetModifiers();
+	ui.mod = glfw_mods_to_ui(mods);
 	run_main_loop();
 	ui_invalidate(); // TODO: leave this to caller
 }
 
-static void on_motion(int x, int y)
+static void on_cursor_pos(GLFWwindow *window, double x, double y)
 {
-	ui.x = x;
-	ui.y = y;
+	ui.x = (int)x;
+	ui.y = (int)y;
 	ui_invalidate();
 }
 
-static void on_passive_motion(int x, int y)
+static void on_framebuffer_size(GLFWwindow *window, int w, int h)
 {
-	ui.x = x;
-	ui.y = y;
-	ui_invalidate();
-}
-
-static void on_reshape(int w, int h)
-{
+	// WAYLAND FIX: Ignore 0x0 compositor hints so the window doesn't collapse
+	if (w == 0 || h == 0) return;
 	ui.window_w = w;
 	ui.window_h = h;
+	ui_invalidate();
 }
 
-static void on_display(void)
+static void on_window_refresh(GLFWwindow *window)
 {
-	void (*old_dialog)(void) = ui.dialog;
-	run_main_loop();
-	if (ui.dialog != old_dialog)
-		ui_invalidate();
+	ui_invalidate();
 }
 
-static void on_error(const char *fmt, va_list ap)
+static void on_error(int error, const char *description)
 {
 #ifdef _WIN32
-	char buf[1000];
-	fz_vsnprintf(buf, sizeof buf, fmt, ap);
-	MessageBoxA(NULL, buf, "MuPDF GLUT Error", MB_ICONERROR);
+	MessageBoxA(NULL, description, "MuPDF GLFW Error", MB_ICONERROR);
 #else
-	fprintf(stderr, "GLUT error: ");
-	vfprintf(stderr, fmt, ap);
-	fprintf(stderr, "\n");
+	fprintf(stderr, "GLFW error %d: %s\n", error, description);
 #endif
 }
 
-static void on_warning(const char *fmt, va_list ap)
-{
-	fprintf(stderr, "GLUT warning: ");
-	vfprintf(stderr, fmt, ap);
-	fprintf(stderr, "\n");
-}
+static double last_timer_check = 0;
 
-static void on_timer(int timer_id)
+void check_timer(void)
 {
-	if (reloadrequested)
+	double now = glfwGetTime();
+	if (now - last_timer_check >= 0.5)
 	{
-		reload();
-		ui_invalidate();
-		reloadrequested = 0;
+		last_timer_check = now;
+		if (reloadrequested)
+		{
+			reload();
+			ui_invalidate();
+			reloadrequested = 0;
+		}
 	}
-	glutTimerFunc(500, on_timer, 0);
 }
 
 void ui_init_dpi(float override_scale)
@@ -414,16 +388,19 @@ void ui_init_dpi(float override_scale)
 	}
 	else
 	{
-		int wmm = glutGet(GLUT_SCREEN_WIDTH_MM);
-		int wpx = glutGet(GLUT_SCREEN_WIDTH);
-		int hmm = glutGet(GLUT_SCREEN_HEIGHT_MM);
-		int hpx = glutGet(GLUT_SCREEN_HEIGHT);
-		if (wmm > 0 && hmm > 0)
+		/*
+		 * GLFW 3.4 supports content scale queries.
+		 * We use the primary monitor's content scale as a DPI hint.
+		 */
+		GLFWmonitor *mon = glfwGetPrimaryMonitor();
+		if (mon)
 		{
-			float ppi = ((wpx * 254) / wmm + (hpx * 254) / hmm) / 20;
-			if (ppi >= 288) ui.scale = 3;
-			else if (ppi >= 192) ui.scale = 2;
-			else if (ppi >= 144) ui.scale = 1.5f;
+			float xscale, yscale;
+			glfwGetMonitorContentScale(mon, &xscale, &yscale);
+			float scale = (xscale + yscale) / 2.0f;
+			if (scale >= 3.0f) ui.scale = 3;
+			else if (scale >= 2.0f) ui.scale = 2;
+			else if (scale >= 1.5f) ui.scale = 1.5f;
 		}
 	}
 
@@ -436,41 +413,47 @@ void ui_init_dpi(float override_scale)
 
 void ui_init(int w, int h, const char *title)
 {
-#ifdef FREEGLUT
-	glutSetOption(GLUT_ACTION_ON_WINDOW_CLOSE, GLUT_ACTION_GLUTMAINLOOP_RETURNS);
-#endif
+	glfwSetErrorCallback(on_error);
 
-	glutInitErrorFunc(on_error);
-	glutInitWarningFunc(on_warning);
-	glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);
-	glutInitWindowSize(w, h);
-	glutCreateWindow(title);
+	glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
+	ui_window = glfwCreateWindow(w, h, title, NULL, NULL);
+	if (!ui_window)
+	{
+		fprintf(stderr, "Failed to create GLFW window\n");
+		exit(1);
+	}
 
-	glutTimerFunc(500, on_timer, 0);
-	glutReshapeFunc(on_reshape);
-	glutDisplayFunc(on_display);
-#if defined(FREEGLUT) && (GLUT_API_VERSION >= 6)
-	glutKeyboardExtFunc(on_keyboard);
-#else
-	fz_warn(ctx, "This version of MuPDF has been built WITHOUT clipboard or unicode input support!");
-	fz_warn(ctx, "Please file a complaint with your friendly local distribution manager.");
-	glutKeyboardFunc(on_keyboard);
-#endif
-	glutSpecialFunc(on_special);
-	glutMouseFunc(on_mouse);
-	glutMotionFunc(on_motion);
-	glutPassiveMotionFunc(on_passive_motion);
-	glutMouseWheelFunc(on_wheel);
+	glfwMakeContextCurrent(ui_window);
+	glfwSwapInterval(1);
 
-	has_ARB_texture_non_power_of_two = glutExtensionSupported("GL_ARB_texture_non_power_of_two");
-	if (!has_ARB_texture_non_power_of_two)
-		fz_warn(ctx, "OpenGL implementation does not support non-power of two texture sizes");
+	glfwSetFramebufferSizeCallback(ui_window, on_framebuffer_size);
+	glfwSetWindowRefreshCallback(ui_window, on_window_refresh);
+	glfwSetKeyCallback(ui_window, on_key);
+	glfwSetCharCallback(ui_window, on_char);
+	glfwSetMouseButtonCallback(ui_window, on_mouse_button);
+	glfwSetCursorPosCallback(ui_window, on_cursor_pos);
+	glfwSetScrollCallback(ui_window, on_scroll);
+
+	/* Create standard cursors */
+	cursor_text = glfwCreateStandardCursor(GLFW_IBEAM_CURSOR);
+	cursor_hresize = glfwCreateStandardCursor(GLFW_RESIZE_EW_CURSOR);
+	cursor_vresize = glfwCreateStandardCursor(GLFW_RESIZE_NS_CURSOR);
+	cursor_crosshair = glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR);
 
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
 
 	ui_init_fonts();
 
 	ui.overlay_list = glGenLists(1);
+
+	/* Initialize framebuffer size */
+	glfwGetFramebufferSize(ui_window, &ui.window_w, &ui.window_h);
+	if (ui.window_w == 0 || ui.window_h == 0) {
+		ui.window_w = w;
+		ui.window_h = h;
+	}
+
+	last_timer_check = glfwGetTime();
 }
 
 void ui_finish(void)
@@ -478,12 +461,29 @@ void ui_finish(void)
 	pdf_drop_annot(ctx, ui.selected_annot);
 	glDeleteLists(ui.overlay_list, 1);
 	ui_finish_fonts();
-	glutExit();
+
+	glfwDestroyCursor(cursor_text);
+	glfwDestroyCursor(cursor_hresize);
+	glfwDestroyCursor(cursor_vresize);
+	glfwDestroyCursor(cursor_crosshair);
+
+	if (ui_window)
+		glfwDestroyWindow(ui_window);
+	glfwTerminate();
 }
+
+static int needs_redisplay = 0;
 
 void ui_invalidate(void)
 {
-	glutPostRedisplay();
+	needs_redisplay = 1;
+}
+
+int ui_needs_redisplay(void)
+{
+	int r = needs_redisplay;
+	needs_redisplay = 0;
+	return r;
 }
 
 void ui_begin(void)
@@ -503,7 +503,7 @@ void ui_begin(void)
 	ui.layout->padx = 0;
 	ui.layout->pady = 0;
 
-	ui.cursor = GLUT_CURSOR_INHERIT;
+	ui.cursor = UI_CURSOR_INHERIT;
 
 	ui.overlay = 0;
 
@@ -527,7 +527,14 @@ void ui_end(void)
 
 	if (ui.cursor != ui.last_cursor)
 	{
-		glutSetCursor(ui.cursor);
+		switch (ui.cursor)
+		{
+		case UI_CURSOR_TEXT: glfwSetCursor(ui_window, cursor_text); break;
+		case UI_CURSOR_LEFT_RIGHT: glfwSetCursor(ui_window, cursor_hresize); break;
+		case UI_CURSOR_UP_DOWN: glfwSetCursor(ui_window, cursor_vresize); break;
+		case UI_CURSOR_CROSSHAIR: glfwSetCursor(ui_window, cursor_crosshair); break;
+		default: glfwSetCursor(ui_window, NULL); break;
+		}
 		ui.last_cursor = ui.cursor;
 	}
 
@@ -556,7 +563,7 @@ void ui_end(void)
 		}
 	}
 
-	glutSwapBuffers();
+	glfwSwapBuffers(ui_window);
 }
 
 /* Widgets */
@@ -931,9 +938,9 @@ void ui_splitter(int *start, int *v, int min, int max, enum side side)
 	if (ui.hot == v || ui.active == v)
 	{
 		if (side == L || side == R)
-			ui.cursor = GLUT_CURSOR_LEFT_RIGHT;
+			ui.cursor = UI_CURSOR_LEFT_RIGHT;
 		else if (side == T || side == B)
-			ui.cursor = GLUT_CURSOR_UP_DOWN;
+			ui.cursor = UI_CURSOR_UP_DOWN;
 	}
 
 	if (side == R)


### PR DESCRIPTION
As many distros are dropping X11 support, I added glfw support which works with Wayland.
freeglut's Wayland backend is quite old and unmaintained (I would get error `failed to discover all needed compositor interfaces`).

`libdecor` is disabled:
```C
glfwInitHint(GLFW_WAYLAND_LIBDECOR, GLFW_WAYLAND_DISABLE_LIBDECOR);
```
because libdecor relies on GTK and its modern sandboxed image loader (glycin) to draw system-themed window icons on Fedora 43. But since MuPDF uses its own event loop instead of the native GLib event loop, glycin permanently deadlocks the main thread while trying to load the "Close" button SVG.

Edit: copy-paste support is also implemented in ce7ebed3beb33261382a6eba9d958e485f5f6b9b .