### PR TITLE
Fix integer overflow in BMP stride bounds check

### DIFF
--- a/source/fitz/load-bmp.c
+++ b/source/fitz/load-bmp.c
@@ -603,7 +603,7 @@ bmp_read_bitmap(fz_context *ctx, struct info *info, const unsigned char *begin, 
 	height = info->height;
 
 	sstride = ((width * bitcount + 31) / 32) * 4;
-	if (ssp + sstride * height > end)
+	if (ssp + (size_t) sstride * height > end)
 	{
 		int32_t h = (end - ssp) / sstride;
 		if (h == 0 || h > SHRT_MAX)
@@ -633,7 +633,7 @@ bmp_read_bitmap(fz_context *ctx, struct info *info, const unsigned char *begin, 
 		dstride = -dstride;
 	}
 
-	if (ssp + sstride * height > end)
+	if (ssp + (size_t) sstride * height > end)
 	{
 		fz_warn(ctx, "premature end in bitmap data in bmp image");
 		height = (end - ssp) / sstride;


### PR DESCRIPTION
The bounds checks at lines 606 and 636 in `source/fitz/load-bmp.c` compute `sstride * height` using `uint32_t` arithmetic, which can wrap around for large dimensions with high bit depths. The actual pixel access at line 668 correctly uses `size_t` casts. This applies the same `size_t` casts to the bounds checks to match.

Found while reviewing the BMP parser for consistency between the bounds checks and the actual data access patterns.