### PR TITLE
[1.23.x] Backport CVE-2026-40505 (Bug 709108: don't print raw font name to terminal)

### DIFF
--- a/source/tools/pdfinfo.c
+++ b/source/tools/pdfinfo.c
@@ -717,7 +717,7 @@ printinfo(fz_context *ctx, globals *glo, char *filename, int show, int page)
 		fz_write_printf(ctx, out, "Fonts (%d):\n", glo->fonts);
 		for (i = 0; i < glo->fonts; i++)
 		{
-			fz_write_printf(ctx, out, PAGE_FMT_zu "%s '%s' %s%s(%d 0 R)\n",
+			fz_write_printf(ctx, out, PAGE_FMT_zu "%s %q %s%s(%d 0 R)\n",
 				glo->font[i].page,
 				pdf_to_num(ctx, glo->font[i].pageref),
 				pdf_to_name(ctx, glo->font[i].u.font.subtype),


### PR DESCRIPTION
backport of `0f17d789fe8c` to `1.23.x` for CVE-2026-40505 / Bug 709108.

the upstream patch sanitizes the font-name string before printing it to the terminal — terminal-escape injection class. one file modified.

upstream: https://github.com/ArtifexSoftware/mupdf/commit/0f17d789fe8c29b41e47663be82514aaca3a4dfb
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-40505

applied via `git cherry-pick -x`; clean apply on `1.23.x` HEAD. (canonical mupdf is at git.ghostscript.com so feel free to mirror the patch across if more useful that way.)