### PR TITLE
[1.22.x] CVE-2026-40505 backport (Bug 709108 font-name terminal escape)

### DIFF
--- a/source/tools/pdfinfo.c
+++ b/source/tools/pdfinfo.c
@@ -717,7 +717,7 @@ printinfo(fz_context *ctx, globals *glo, char *filename, int show, int page)
 		fz_write_printf(ctx, out, "Fonts (%d):\n", glo->fonts);
 		for (i = 0; i < glo->fonts; i++)
 		{
-			fz_write_printf(ctx, out, PAGE_FMT_zu "%s '%s' %s%s(%d 0 R)\n",
+			fz_write_printf(ctx, out, PAGE_FMT_zu "%s %q %s%s(%d 0 R)\n",
 				glo->font[i].page,
 				pdf_to_num(ctx, glo->font[i].pageref),
 				pdf_to_name(ctx, glo->font[i].u.font.subtype),


### PR DESCRIPTION
same backport as the `1.23.x` PR but for `1.22.x`. upstream sha `0f17d789fe8c` (Bug 709108 / CVE-2026-40505) sanitizes raw font-name output to the terminal.

- https://github.com/ArtifexSoftware/mupdf/commit/0f17d789fe8c29b41e47663be82514aaca3a4dfb
- https://nvd.nist.gov/vuln/detail/CVE-2026-40505

clean cherry-pick. no local test run.