### PR TITLE
Fix stack buffer overflow in CFF blend opcode handler

### DIFF
--- a/source/fitz/subset-cff.c
+++ b/source/fitz/subset-cff.c
@@ -1209,6 +1209,8 @@ overflow:
 			/* Consumes a lot of operators, leaves n, where n = stack[sp-1]. */
 			ATLEAST(1);
 			sp = stack[sp-1];
+			if (sp < 0 || sp > (int)(sizeof(stack)/sizeof(*stack)))
+				fz_throw(ctx, FZ_ERROR_FORMAT, "Stack overflow in blend");
 			break;
 		case 29: /* callgsubr */
 			ATLEAST(1);


### PR DESCRIPTION
## Summary

Fix a stack buffer overflow in the CFF charstring blend opcode handler in `source/fitz/subset-cff.c`.

## Problem

The `blend` opcode (case 16) in `execute_charstring()` assigns the operand stack pointer `sp` directly from an attacker-controlled charstring value without upper-bound validation:

`c
case 16: /* blend */
    ATLEAST(1);
    sp = stack[sp-1];  // no upper-bound check
    break;
`

`stack` is declared as `double stack[513]` (4104 bytes on the C stack). Every other opcode that modifies `sp` uses the `PUSH` macro which enforces `sp + n <= sizeof(stack)/sizeof(*stack)`. The `blend` handler bypasses this, allowing out-of-bounds read/write past the stack buffer.

## Fix

Add a bounds check after the assignment, consistent with the existing `PUSH` macro pattern and using the same overflow constant and error mechanism:

`c
sp = stack[sp-1];
if (sp < 0 || sp > (int)(sizeof(stack)/sizeof(*stack)))
    fz_throw(ctx, FZ_ERROR_FORMAT, "Stack overflow in blend");
`

## Testing

Tested with crafted CFF fonts containing blend opcodes with out-of-range operands â€” the fix correctly throws `FZ_ERROR_FORMAT` instead of corrupting the stack.

## CWE References

- CWE-787 (Out-of-bounds Write)
- CWE-125 (Out-of-bounds Read)