### PR TITLE
pdf-object.c: Include UINT_MAX definition and fix FTBFS

### DIFF
--- a/source/pdf/pdf-object.c
+++ b/source/pdf/pdf-object.c
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <math.h>
 #include <zlib.h> /* for crc32 */
 


### PR DESCRIPTION
59aed0383 ("Bug 709343: Speed up mutool clean garbage collection by hashing objects.", 2026-06-24) introduced usage of UINT_MAX in this file, so include the definition.