### PR TITLE
Replace removed Python 2 C API macros for SWIG 4.5.0 compatibility

### DIFF
--- a/scripts/wrap/swig.py
+++ b/scripts/wrap/swig.py
@@ -740,7 +740,7 @@ def build_swig(
                 {
                     message += "Traceback (from traceback.format_tb()):\\n";
                     PyObject* traceback_dict = PyModule_GetDict(traceback);
-                    PyObject* format_tb = PyDict_GetItem(traceback_dict, PyString_FromString("format_tb"));
+                    PyObject* format_tb = PyDict_GetItem(traceback_dict, PyUnicode_FromString("format_tb"));
                     PyObject* ret = PyObject_CallFunctionObjArgs(format_tb, trace, NULL);
                     PyObject* iter = PyObject_GetIter(ret);
                     for(;;)


### PR DESCRIPTION
SWIG was carrying thus macros before version 4.5.0, but they were never necessary in Python 3. Stop using for compatibility with upcoming SWIG 4.5.0.

Suggested-by: Jitka Plesnikova <jplesnik@redhat.com>