### PR TITLE
Optimize transparent RGBA to RGB spans

### DIFF
--- a/source/fitz/draw-paint.c
+++ b/source/fitz/draw-paint.c
@@ -2084,7 +2084,26 @@ static void
 paint_span_3_sa(byte * FZ_RESTRICT dp, int da, const byte * FZ_RESTRICT sp, int sa, int n, int w, int alpha, const fz_overprint * FZ_RESTRICT eop)
 {
 	TRACK_FN();
-	template_span_3_general(dp, 0, sp, 1, w);
+
+	/*
+		Transparent leading runs are common when compositing an RGBA group
+		on an RGB destination. Skip them four pixels at a time, then retain
+		the existing painter unchanged for all remaining pixels.
+	*/
+	while (w >= 4 && (sp[3] | sp[7] | sp[11] | sp[15]) == 0)
+	{
+		sp += 16;
+		dp += 12;
+		w -= 4;
+	}
+	while (w > 0 && sp[3] == 0)
+	{
+		sp += 4;
+		dp += 3;
+		--w;
+	}
+	if (w > 0)
+		template_span_3_general(dp, 0, sp, 1, w);
 }
 
 static void


### PR DESCRIPTION
Bugzilla: https://bugs.ghostscript.com/show_bug.cgi?id=709608

## Summary

Optimize `paint_span_3_sa`, the RGBA-source to RGB-destination compositing hot path, by skipping leading fully transparent pixels four at a time.

The existing painter and blending arithmetic remain unchanged for all remaining opaque and partial-alpha pixels.

## Motivation

Profiling an 80-page PDF rendering workload at 300 DPI showed that `paint_span_3_sa` accounted for approximately 64.6% of sampled runtime.

Instrumentation of transparency-heavy PDF workloads showed that fully transparent pixels represented 8388% of the pixels processed by this function.

## Performance

The baseline and optimized commits were rebuilt from scratch in separate build directories using the same compiler, flags, and dependencies.

The benchmark used:

* CPU affinity pinned to one CPU
* Paired baseline/optimized measurements
* Alternating execution order
* 11 measurement pairs per document
* Adaptive repetition for short documents
* 95% bootstrap confidence intervals

Results across all 27 PDFs included in the MuPDF source tree:

* Aggregate rendering time: 7.15% faster
* Median per-document change: 1.28% faster
* Statistically significant improvements: 6 documents
* Statistically significant regressions: 0 documents

Transparency-heavy workloads:

| Workload                 | Improvement |
| ------------------------ | ----------: |
| LittleCMS API PDF        |      16.06% |
| LittleCMS Plugin API PDF |      16.22% |
| LittleCMS tutorial PDF   |      10.35% |

A focused fully transparent microbenchmark improved by approximately 6.2x.

Opaque, partial-alpha, sparse-alpha, and random-alpha paths remained within benchmark noise because the existing painter is retained for all remaining pixels.

## Correctness validation

### MuPDF in-tree corpus

* All 27 PDFs were tested.
* Exact rendered page hashes matched for every document.
* No rendering differences were found.

### Independent PDF.js corpus

A deterministic size-stratified selection of 100 PDFs was taken from Mozilla PDF.js's 974-file test corpus.

* Equivalent result or error behavior: 100/100 files
* Successfully rendered by both builds: 90 files
* Exact rendered page hashes matched: 90/90 files
* Rendering mismatches: 0

Initially flagged performance regressions were all on very short 732 ms workloads. Instrumentation showed that the changed function was not called in those cases.

The flagged documents were remeasured by repeating their pages 50893 times within a single MuPDF process. No statistically significant regressions remained.

## Additional validation

* 250,000 randomized old-versus-new equivalence tests passed under ASan and UBSan with guard zones.
* Final ASan rendering and text-extraction workloads passed.
* Text extraction for all 185 pages of the LittleCMS API PDF matched byte-for-byte.
* Release build passed.
* `git diff --check` passed.

The project's combined UBSan configuration reports an unrelated pre-existing signed-shift issue in bundled libjpeg at `thirdparty/libjpeg/jidctint.c:244`.